### PR TITLE
Make RenderPassEncoder.End() the same for different builds

### DIFF
--- a/wgpu/render_pass_js.go
+++ b/wgpu/render_pass_js.go
@@ -81,8 +81,9 @@ func (g RenderPassEncoder) DrawIndexed(indexCount uint32, instanceCount uint32, 
 
 // End as described:
 // https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-end
-func (g RenderPassEncoder) End() {
+func (g RenderPassEncoder) End() error {
 	g.jsValue.Call("end")
+	return nil
 }
 
 func (g RenderPassEncoder) Release() {} // no-op


### PR DESCRIPTION
The javascript build was missing the error return value. This makes it impossible to cross build when checking this return value.