### PR TITLE
V25: update to wgpu_native v25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WebGPU
 
+Current upstream version: v25.0.2.1
+
 Go bindings for WebGPU, a cross-platform, safe graphics API. It runs natively using [wgpu-native](https://github.com/gfx-rs/wgpu-native) on Vulkan, Metal, D3D12, and OpenGL ES based on https://github.com/rajveermalviya/go-webgpu. It also comes with web (JS) support based on https://github.com/mokiat/wasmgpu.
 
 For more information, see:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WebGPU
 
 Current upstream version: v25.0.2.1
+* Use [getrelease.goal](getrelease.goal) for current mechanism to get the released `wgpu-native` libraries downloaded and installed. The libraries will be committed to this repo when v26 comes out, but for now, this is required.
 
 Go bindings for WebGPU, a cross-platform, safe graphics API. It runs natively using [wgpu-native](https://github.com/gfx-rs/wgpu-native) on Vulkan, Metal, D3D12, and OpenGL ES based on https://github.com/rajveermalviya/go-webgpu. It also comes with web (JS) support based on https://github.com/mokiat/wasmgpu.
 

--- a/examples/boids/main.go
+++ b/examples/boids/main.go
@@ -110,7 +110,7 @@ func InitState(window *glfw.Window) (s *State, err error) {
 
 	computeShader, err := s.device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
 		Label: "compute.wgsl",
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{
+		WGSLSource: &wgpu.ShaderSourceWGSL{
 			Code: compute,
 		},
 	})
@@ -121,7 +121,7 @@ func InitState(window *glfw.Window) (s *State, err error) {
 
 	drawShader, err := s.device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
 		Label: "draw.wgsl",
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{
+		WGSLSource: &wgpu.ShaderSourceWGSL{
 			Code: draw,
 		},
 	})

--- a/examples/capture/main.go
+++ b/examples/capture/main.go
@@ -132,9 +132,9 @@ func main() {
 	// Copy the data from the texture to the buffer
 	encoder.CopyTextureToBuffer(
 		texture.AsImageCopy(),
-		&wgpu.ImageCopyBuffer{
+		&wgpu.TexelCopyBufferInfo{
 			Buffer: outputBuffer,
-			Layout: wgpu.TextureDataLayout{
+			Layout: wgpu.TexelCopyBufferLayout{
 				Offset:       0,
 				BytesPerRow:  uint32(bufferDimensions.paddedBytesPerRow),
 				RowsPerImage: wgpu.CopyStrideUndefined,
@@ -151,14 +151,14 @@ func main() {
 
 	queue.Submit(cmdBuffer)
 
-	outputBuffer.MapAsync(wgpu.MapModeRead, 0, bufferSize, func(status wgpu.BufferMapAsyncStatus) {
-		if status != wgpu.BufferMapAsyncStatusSuccess {
+	outputBuffer.MapAsync(wgpu.MapModeRead, 0, bufferSize, func(status wgpu.MapAsyncStatus) {
+		if status != wgpu.MapAsyncStatusSuccess {
 			panic("failed to map buffer")
 		}
 	})
 	defer outputBuffer.Unmap()
 
-	device.Poll(true, nil)
+	device.Poll(true, 0)
 
 	data := outputBuffer.GetMappedRange(0, uint(bufferSize))
 

--- a/examples/capture/main.go
+++ b/examples/capture/main.go
@@ -158,7 +158,7 @@ func main() {
 	})
 	defer outputBuffer.Unmap()
 
-	device.Poll(true, 0)
+	device.Poll(true, nil)
 
 	data := outputBuffer.GetMappedRange(0, uint(bufferSize))
 

--- a/examples/compute/main.go
+++ b/examples/compute/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 	defer stagingBuffer.Unmap()
 
-	device.Poll(true, 0)
+	device.Poll(true, nil)
 
 	if status != wgpu.MapAsyncStatusSuccess {
 		panic(status)

--- a/examples/compute/main.go
+++ b/examples/compute/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	shaderModule, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
 		Label: "shader.wgsl",
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{
+		WGSLSource: &wgpu.ShaderSourceWGSL{
 			Code: shader,
 		},
 	})
@@ -141,8 +141,8 @@ func main() {
 	}
 	queue.Submit(cmdBuffer)
 
-	var status wgpu.BufferMapAsyncStatus
-	err = stagingBuffer.MapAsync(wgpu.MapModeRead, 0, size, func(s wgpu.BufferMapAsyncStatus) {
+	var status wgpu.MapAsyncStatus
+	err = stagingBuffer.MapAsync(wgpu.MapModeRead, 0, size, func(s wgpu.MapAsyncStatus) {
 		status = s
 	})
 	if err != nil {
@@ -150,9 +150,9 @@ func main() {
 	}
 	defer stagingBuffer.Unmap()
 
-	device.Poll(true, nil)
+	device.Poll(true, 0)
 
-	if status != wgpu.BufferMapAsyncStatusSuccess {
+	if status != wgpu.MapAsyncStatusSuccess {
 		panic(status)
 	}
 

--- a/examples/cube/main.go
+++ b/examples/cube/main.go
@@ -243,7 +243,7 @@ func InitState(window *glfw.Window) (s *State, err error) {
 	s.queue.WriteTexture(
 		texture.AsImageCopy(),
 		wgpu.ToBytes(texels[:]),
-		&wgpu.TextureDataLayout{
+		&wgpu.TexelCopyBufferLayout{
 			Offset:       0,
 			BytesPerRow:  texelsSize,
 			RowsPerImage: wgpu.CopyStrideUndefined,
@@ -262,8 +262,8 @@ func InitState(window *glfw.Window) (s *State, err error) {
 	}
 
 	shader, err := s.device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
-		Label:          "shader.wgsl",
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{Code: shader},
+		Label:      "shader.wgsl",
+		WGSLSource: &wgpu.ShaderSourceWGSL{Code: shader},
 	})
 	if err != nil {
 		return s, err

--- a/examples/triangle/main.go
+++ b/examples/triangle/main.go
@@ -72,8 +72,8 @@ func InitState[T interface{ GetSize() (int, int) }](window T, sd *wgpu.SurfaceDe
 	s.queue = s.device.GetQueue()
 
 	shader, err := s.device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
-		Label:          "shader.wgsl",
-		WGSLDescriptor: &wgpu.ShaderModuleWGSLDescriptor{Code: shader},
+		Label:      "shader.wgsl",
+		WGSLSource: &wgpu.ShaderSourceWGSL{Code: shader},
 	})
 	if err != nil {
 		return s, err

--- a/getrelease.goal
+++ b/getrelease.goal
@@ -6,7 +6,8 @@
 // * lib-old.goal to switch lib-> lib_new, lib_old -> lib
 // * lib-new.goal to go the other way
 // notes:
-// requires gh tool
+// requires gh tool: https://github.com/cli/cli with authentication configured.
+// and goal: go install cogentcore.org/lab/goal/cmd/goal@main
 
 [mkdir release]
 cd release

--- a/getrelease.goal
+++ b/getrelease.goal
@@ -1,0 +1,62 @@
+#!/usr/bin/env goal
+
+// gets the prebuilt release files from wgpu-native and installs
+// to wgpu/lib, moving exiting lib to lib_old.
+// after doing this, use:
+// * lib-old.goal to switch lib-> lib_new, lib_old -> lib
+// * lib-new.goal to go the other way
+// notes:
+// requires gh tool
+
+[mkdir release]
+cd release
+[/bin/rm -rf wgpu-native]
+[/bin/rm -rf zips]
+[mkdir zips]
+git clone https://github.com/gfx-rs/wgpu-native
+cd wgpu-native
+gh release download --dir ../zips -p "*-release.zip"
+cd ../zips
+zips := goalib.SplitLines($ls -1 "*.zip"$)
+cd ../..
+mv wgpu/lib wgpu/lib_old
+[/bin/rm -rf wgpu/lib]
+mkdir wgpu/lib
+cd wgpu/lib
+for _, f := range zips {
+	fmt.Println(f)
+	if strings.Contains(f, "-x86_64-msvc-") || strings.Contains(f, "-aarch64-simulator-") {
+		continue
+	}
+	sp := strings.Split(f, "-")
+	plt := strings.Join(sp[1:3], "-")
+	[mkdir {plt}]
+	cd {plt}
+	unzip {"../../../release/zips/" + f}
+	cd ../
+}
+
+/bin/cp ../lib_old/vendor.go .
+
+type files struct {
+	zip, trg, arch string
+}
+
+fls := []files{{"macos-aarch64", "darwin", "arm64"},{"macos-x86_64", "darwin", "amd64"},{"ios-aarch64", "ios", "arm64"},{"ios-x86_64", "ios", "amd64"},{"windows-aarch64", "windows", "arm64"},{"windows-x86_64", "windows", "amd64"}, {"windows-i686", "windows", "386"}, {"linux-aarch64", "linux", "arm64"},{"linux-x86_64", "linux", "amd64"}, {"android-aarch64", "android", "arm64"}, {"android-x86_64", "android", "amd64"}, {"android-armv7", "android", "arm"},{"android-i686", "android", "386"}}
+
+for _, f := range fls {
+	fmt.Println(f)
+	[mkdir {f.trg}]
+	cd {f.trg}
+	[mkdir {f.arch}]
+	cd {f.arch}
+	[/bin/cp -av {"../../" + f.zip + "/lib/libwgpu_native.a"} .]
+	if f.zip == "windows-aarch64" {
+		/bin/cp -av {"../../" + f.zip + "/lib/wgpu_native.lib"} libwgpu_native.a
+	}
+	/bin/cp -av {"../../" + f.zip + "/include/webgpu/*.h"} .
+	goalib.WriteFile("vendor.go", "package vendor")
+	cd ../../
+	/bin/rm -rf {f.zip}
+}
+

--- a/lib-new.goal
+++ b/lib-new.goal
@@ -1,0 +1,8 @@
+#!/usr/bin/env goal
+
+// moves current wgpu/lib to wgpu/lib_old
+// and restores wgpu/lib_new as wgpu/lib
+
+mv wgpu/lib wgpu/lib_old
+mv wgpu/lib_new wgpu/lib
+

--- a/lib-old.goal
+++ b/lib-old.goal
@@ -1,0 +1,8 @@
+#!/usr/bin/env goal
+
+// moves current wgpu/lib to wgpu/lib_new
+// and restores wgpu/lib_old as wgpu/lib
+
+mv wgpu/lib wgpu/lib_new
+mv wgpu/lib_old wgpu/lib
+

--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, char const *message, void *userdata);
 extern void gowebgpu_device_lost_callback_c(WGPUDeviceLostReason reason, char const * message, void * userdata);

--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -22,63 +22,61 @@ type Adapter struct {
 	ref C.WGPUAdapter
 }
 
-func (p *Adapter) EnumerateFeatures() []FeatureName {
-	size := C.wgpuAdapterEnumerateFeatures(p.ref, nil)
+func (p *Adapter) GetFeatures() []FeatureName {
+	size := C.wgpuAdapterGetFeatures(p.ref, nil)
 	if size == 0 {
 		return nil
 	}
 
 	features := make([]FeatureName, size)
-	C.wgpuAdapterEnumerateFeatures(p.ref, (*C.WGPUFeatureName)(unsafe.Pointer(&features[0])))
+	C.wgpuAdapterGetFeatures(p.ref, (*C.WGPUFeatureName)(unsafe.Pointer(&features[0])))
 	return features
 }
 
-func (p *Adapter) GetLimits() SupportedLimits {
-	var supportedLimits C.WGPUSupportedLimits
+func (p *Adapter) GetLimits() Limits {
+	var limits C.WGPULimits
 
-	extras := (*C.WGPUSupportedLimitsExtras)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSupportedLimitsExtras{}))))
-	defer C.free(unsafe.Pointer(extras))
-	supportedLimits.nextInChain = (*C.WGPUChainedStructOut)(unsafe.Pointer(extras))
+	nativeLimits := (*C.WGPUNativeLimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUNativeLimits{}))))
+	defer C.free(unsafe.Pointer(nativeLimits))
+	limits.nextInChain = (*C.WGPUChainedStructOut)(unsafe.Pointer(nativeLimits))
 
-	C.wgpuAdapterGetLimits(p.ref, &supportedLimits)
+	C.wgpuAdapterGetLimits(p.ref, &limits)
 
-	limits := supportedLimits.limits
-	return SupportedLimits{
-		Limits{
-			MaxTextureDimension1D:                     uint32(limits.maxTextureDimension1D),
-			MaxTextureDimension2D:                     uint32(limits.maxTextureDimension2D),
-			MaxTextureDimension3D:                     uint32(limits.maxTextureDimension3D),
-			MaxTextureArrayLayers:                     uint32(limits.maxTextureArrayLayers),
-			MaxBindGroups:                             uint32(limits.maxBindGroups),
-			MaxBindingsPerBindGroup:                   uint32(limits.maxBindingsPerBindGroup),
-			MaxDynamicUniformBuffersPerPipelineLayout: uint32(limits.maxDynamicUniformBuffersPerPipelineLayout),
-			MaxDynamicStorageBuffersPerPipelineLayout: uint32(limits.maxDynamicStorageBuffersPerPipelineLayout),
-			MaxSampledTexturesPerShaderStage:          uint32(limits.maxSampledTexturesPerShaderStage),
-			MaxSamplersPerShaderStage:                 uint32(limits.maxSamplersPerShaderStage),
-			MaxStorageBuffersPerShaderStage:           uint32(limits.maxStorageBuffersPerShaderStage),
-			MaxStorageTexturesPerShaderStage:          uint32(limits.maxStorageTexturesPerShaderStage),
-			MaxUniformBuffersPerShaderStage:           uint32(limits.maxUniformBuffersPerShaderStage),
-			MaxUniformBufferBindingSize:               uint64(limits.maxUniformBufferBindingSize),
-			MaxStorageBufferBindingSize:               uint64(limits.maxStorageBufferBindingSize),
-			MinUniformBufferOffsetAlignment:           uint32(limits.minUniformBufferOffsetAlignment),
-			MinStorageBufferOffsetAlignment:           uint32(limits.minStorageBufferOffsetAlignment),
-			MaxVertexBuffers:                          uint32(limits.maxVertexBuffers),
-			MaxBufferSize:                             uint64(limits.maxBufferSize),
-			MaxVertexAttributes:                       uint32(limits.maxVertexAttributes),
-			MaxVertexBufferArrayStride:                uint32(limits.maxVertexBufferArrayStride),
-			MaxInterStageShaderComponents:             uint32(limits.maxInterStageShaderComponents),
-			MaxInterStageShaderVariables:              uint32(limits.maxInterStageShaderVariables),
-			MaxColorAttachments:                       uint32(limits.maxColorAttachments),
-			MaxColorAttachmentBytesPerSample:          uint32(limits.maxColorAttachmentBytesPerSample),
-			MaxComputeWorkgroupStorageSize:            uint32(limits.maxComputeWorkgroupStorageSize),
-			MaxComputeInvocationsPerWorkgroup:         uint32(limits.maxComputeInvocationsPerWorkgroup),
-			MaxComputeWorkgroupSizeX:                  uint32(limits.maxComputeWorkgroupSizeX),
-			MaxComputeWorkgroupSizeY:                  uint32(limits.maxComputeWorkgroupSizeY),
-			MaxComputeWorkgroupSizeZ:                  uint32(limits.maxComputeWorkgroupSizeZ),
-			MaxComputeWorkgroupsPerDimension:          uint32(limits.maxComputeWorkgroupsPerDimension),
+	return Limits{
+		MaxTextureDimension1D:                     uint32(limits.maxTextureDimension1D),
+		MaxTextureDimension2D:                     uint32(limits.maxTextureDimension2D),
+		MaxTextureDimension3D:                     uint32(limits.maxTextureDimension3D),
+		MaxTextureArrayLayers:                     uint32(limits.maxTextureArrayLayers),
+		MaxBindGroups:                             uint32(limits.maxBindGroups),
+		MaxBindingsPerBindGroup:                   uint32(limits.maxBindingsPerBindGroup),
+		MaxDynamicUniformBuffersPerPipelineLayout: uint32(limits.maxDynamicUniformBuffersPerPipelineLayout),
+		MaxDynamicStorageBuffersPerPipelineLayout: uint32(limits.maxDynamicStorageBuffersPerPipelineLayout),
+		MaxSampledTexturesPerShaderStage:          uint32(limits.maxSampledTexturesPerShaderStage),
+		MaxSamplersPerShaderStage:                 uint32(limits.maxSamplersPerShaderStage),
+		MaxStorageBuffersPerShaderStage:           uint32(limits.maxStorageBuffersPerShaderStage),
+		MaxStorageTexturesPerShaderStage:          uint32(limits.maxStorageTexturesPerShaderStage),
+		MaxUniformBuffersPerShaderStage:           uint32(limits.maxUniformBuffersPerShaderStage),
+		MaxUniformBufferBindingSize:               uint64(limits.maxUniformBufferBindingSize),
+		MaxStorageBufferBindingSize:               uint64(limits.maxStorageBufferBindingSize),
+		MinUniformBufferOffsetAlignment:           uint32(limits.minUniformBufferOffsetAlignment),
+		MinStorageBufferOffsetAlignment:           uint32(limits.minStorageBufferOffsetAlignment),
+		MaxVertexBuffers:                          uint32(limits.maxVertexBuffers),
+		MaxBufferSize:                             uint64(limits.maxBufferSize),
+		MaxVertexAttributes:                       uint32(limits.maxVertexAttributes),
+		MaxVertexBufferArrayStride:                uint32(limits.maxVertexBufferArrayStride),
+		MaxInterStageShaderComponents:             uint32(limits.maxInterStageShaderComponents),
+		MaxInterStageShaderVariables:              uint32(limits.maxInterStageShaderVariables),
+		MaxColorAttachments:                       uint32(limits.maxColorAttachments),
+		MaxColorAttachmentBytesPerSample:          uint32(limits.maxColorAttachmentBytesPerSample),
+		MaxComputeWorkgroupStorageSize:            uint32(limits.maxComputeWorkgroupStorageSize),
+		MaxComputeInvocationsPerWorkgroup:         uint32(limits.maxComputeInvocationsPerWorkgroup),
+		MaxComputeWorkgroupSizeX:                  uint32(limits.maxComputeWorkgroupSizeX),
+		MaxComputeWorkgroupSizeY:                  uint32(limits.maxComputeWorkgroupSizeY),
+		MaxComputeWorkgroupSizeZ:                  uint32(limits.maxComputeWorkgroupSizeZ),
+		MaxComputeWorkgroupsPerDimension:          uint32(limits.maxComputeWorkgroupsPerDimension),
 
-			MaxPushConstantSize: uint32(extras.limits.maxPushConstantSize),
-		},
+		MaxPushConstantSize:   uint32(nativeLimits.limits.maxPushConstantSize),
+		MaxNonSamplerBindings: uint32(nativeLimits.maxNonSamplerBindings),
 	}
 }
 
@@ -154,10 +152,10 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 		}
 
 		if descriptor.RequiredLimits != nil {
-			requiredLimits := (*C.WGPURequiredLimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPURequiredLimits{}))))
+			requiredLimits := (*C.WGPULimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPULimits{}))))
 			defer C.free(unsafe.Pointer(requiredLimits))
 
-			l := descriptor.RequiredLimits.Limits
+			l := descriptor.RequiredLimits
 			requiredLimits.limits = C.WGPULimits{
 				maxTextureDimension1D:                     C.uint32_t(l.MaxTextureDimension1D),
 				maxTextureDimension2D:                     C.uint32_t(l.MaxTextureDimension2D),
@@ -192,14 +190,15 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 			}
 			desc.requiredLimits = requiredLimits
 
-			requiredLimitsExtras := (*C.WGPURequiredLimitsExtras)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPURequiredLimitsExtras{}))))
-			defer C.free(unsafe.Pointer(requiredLimitsExtras))
+			nativeLimits := (*C.WGPUNativeLimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUNativeLimits{}))))
+			defer C.free(unsafe.Pointer(nativeLimits))
 
-			requiredLimitsExtras.chain.next = nil
-			requiredLimitsExtras.chain.sType = C.WGPUSType_RequiredLimitsExtras
-			requiredLimitsExtras.limits.maxPushConstantSize = C.uint32_t(l.MaxPushConstantSize)
+			nativeLimits.chain.next = nil
+			nativeLimits.chain.sType = C.WGPUSType_NativeLimits
+			nativeLimits.maxPushConstantSize = C.uint32_t(l.MaxPushConstantSize)
+			nativeLimits.maxNonSamplerBindings = C.uint32_t(l.MaxNonSamplerBindings)
 
-			desc.requiredLimits.nextInChain = (*C.WGPUChainedStruct)(unsafe.Pointer(requiredLimitsExtras))
+			desc.requiredLimits.nextInChain = (*C.WGPUChainedStruct)(unsafe.Pointer(nativeLimits))
 		}
 
 		if descriptor.DeviceLostCallback != nil {
@@ -233,7 +232,10 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 		device = d
 	}
 	handle := cgo.NewHandle(cb)
-	C.wgpuAdapterRequestDevice(p.ref, desc, C.WGPUAdapterRequestDeviceCallback(C.gowebgpu_request_device_callback_c), unsafe.Pointer(&handle))
+	C.wgpuAdapterRequestDevice(p.ref, desc, C.WGPURequestDeviceCallbackInfo{
+		callback:  C.gowebgpu_request_device_callback_c,
+		userdata1: unsafe.Pointer(&handle),
+	})
 
 	if status != RequestDeviceStatusSuccess {
 		return nil, errors.New("failed to request device")

--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -75,7 +75,7 @@ func (p *Adapter) GetLimits() Limits {
 		MaxComputeWorkgroupSizeZ:                  uint32(limits.maxComputeWorkgroupSizeZ),
 		MaxComputeWorkgroupsPerDimension:          uint32(limits.maxComputeWorkgroupsPerDimension),
 
-		MaxPushConstantSize:   uint32(nativeLimits.limits.maxPushConstantSize),
+		MaxPushConstantSize:   uint32(nativeLimits.maxPushConstantSize),
 		MaxNonSamplerBindings: uint32(nativeLimits.maxNonSamplerBindings),
 	}
 }

--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -108,13 +108,13 @@ func (p *Adapter) HasFeature(feature FeatureName) bool {
 type requestDeviceCb func(status RequestDeviceStatus, device *Device, message string)
 
 //export gowebgpu_request_device_callback_go
-func gowebgpu_request_device_callback_go(status C.WGPURequestDeviceStatus, device C.WGPUDevice, message *C.char, userdata unsafe.Pointer) {
+func gowebgpu_request_device_callback_go(status C.WGPURequestDeviceStatus, device C.WGPUDevice, message C.WGPUStringView, userdata unsafe.Pointer) {
 	handle := *(*cgo.Handle)(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(requestDeviceCb)
 	if ok {
-		cb(RequestDeviceStatus(status), &Device{ref: device}, C.GoString(message))
+		cb(RequestDeviceStatus(status), &Device{ref: device}, C.GoStringN(message.data, C.int(message.length)))
 	}
 }
 

--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -158,7 +158,10 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 		if descriptor.RequiredLimits != nil {
 			l := descriptor.RequiredLimits
 
-			requiredLimits := C.WGPULimits{
+			requiredLimits := (*C.WGPULimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPULimits{}))))
+			defer C.free(unsafe.Pointer(requiredLimits))
+
+			*requiredLimits = C.WGPULimits{
 				maxTextureDimension1D:                     C.uint32_t(l.MaxTextureDimension1D),
 				maxTextureDimension2D:                     C.uint32_t(l.MaxTextureDimension2D),
 				maxTextureDimension3D:                     C.uint32_t(l.MaxTextureDimension3D),
@@ -189,8 +192,7 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 				maxComputeWorkgroupSizeZ:                  C.uint32_t(l.MaxComputeWorkgroupSizeZ),
 				maxComputeWorkgroupsPerDimension:          C.uint32_t(l.MaxComputeWorkgroupsPerDimension),
 			}
-
-			desc.requiredLimits = &requiredLimits
+			desc.requiredLimits = requiredLimits
 
 			nativeLimits := (*C.WGPUNativeLimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUNativeLimits{}))))
 			defer C.free(unsafe.Pointer(nativeLimits))

--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 extern void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata);

--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -7,19 +7,31 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
-extern void gowebgpu_buffer_map_callback_c(WGPUBufferMapAsyncStatus status, void *userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
+extern void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata);
 
-static inline void gowebgpu_buffer_map_async(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapAsyncCallback callback, void * userdata, WGPUDevice device, void * error_userdata) {
+static inline void gowebgpu_buffer_map_async(WGPUBuffer buffer, WGPUMapMode mode, size_t offset, size_t size, WGPUBufferMapCallbackInfo callback, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
-	wgpuBufferMapAsync(buffer, mode, offset, size, callback, userdata);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+	wgpuBufferMapAsync(buffer, mode, offset, size, callback);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_buffer_unmap(WGPUBuffer buffer, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuBufferUnmap(buffer);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_buffer_release(WGPUBuffer buffer, WGPUDevice device) {
@@ -58,13 +70,13 @@ func (p *Buffer) GetUsage() BufferUsage {
 }
 
 //export gowebgpu_buffer_map_callback_go
-func gowebgpu_buffer_map_callback_go(status C.WGPUBufferMapAsyncStatus, userdata unsafe.Pointer) {
+func gowebgpu_buffer_map_callback_go(status C.WGPUMapAsyncStatus, userdata unsafe.Pointer) {
 	handle := *(*cgo.Handle)(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(BufferMapCallback)
 	if ok {
-		cb(BufferMapAsyncStatus(status))
+		cb(MapAsyncStatus(status))
 	}
 }
 
@@ -79,11 +91,13 @@ func (p *Buffer) MapAsync(mode MapMode, offset uint64, size uint64, callback Buf
 
 	C.gowebgpu_buffer_map_async(
 		p.ref,
-		C.WGPUMapModeFlags(mode),
+		C.WGPUMapMode(mode),
 		C.size_t(offset),
 		C.size_t(size),
-		(C.WGPUBufferMapAsyncCallback)(C.gowebgpu_buffer_map_callback_c),
-		unsafe.Pointer(&callbackHandle),
+		C.WGPUBufferMapCallbackInfo{
+			callback:  C.gowebgpu_buffer_map_callback_c,
+			userdata1: unsafe.Pointer(&callbackHandle),
+		},
 		p.deviceRef,
 		unsafe.Pointer(&errorCallbackHandle),
 	)

--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -8,7 +8,8 @@ package wgpu
 #include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
-extern void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata);
+
+extern void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, WGPUStringView message, void *userdata, void *userdata2);
 
 static inline void gowebgpu_buffer_map_async(WGPUBuffer buffer, WGPUMapMode mode, size_t offset, size_t size, WGPUBufferMapCallbackInfo callback, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);

--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -95,7 +95,7 @@ func (p *Buffer) MapAsync(mode MapMode, offset uint64, size uint64, callback Buf
 		C.size_t(offset),
 		C.size_t(size),
 		C.WGPUBufferMapCallbackInfo{
-			callback:  C.gowebgpu_buffer_map_callback_c,
+			callback:  C.WGPUBufferMapCallback(C.gowebgpu_buffer_map_callback_c),
 			userdata1: unsafe.Pointer(&callbackHandle),
 		},
 		p.deviceRef,

--- a/wgpu/command_encoder.go
+++ b/wgpu/command_encoder.go
@@ -7,74 +7,141 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
 static inline void gowebgpu_command_encoder_clear_buffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderClearBuffer(commandEncoder, buffer, offset, size);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_copy_buffer_to_buffer(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderCopyBufferToBuffer(commandEncoder, source, sourceOffset, destination, destinationOffset, size);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
-static inline void gowebgpu_command_encoder_copy_buffer_to_texture(WGPUCommandEncoder commandEncoder, WGPUImageCopyBuffer const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
+static inline void gowebgpu_command_encoder_copy_buffer_to_texture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyBufferInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderCopyBufferToTexture(commandEncoder, source, destination, copySize);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
-static inline void gowebgpu_command_encoder_copy_texture_to_buffer(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyBuffer const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
+static inline void gowebgpu_command_encoder_copy_texture_to_buffer(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyBufferInfo const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderCopyTextureToBuffer(commandEncoder, source, destination, copySize);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
-static inline void gowebgpu_command_encoder_copy_texture_to_texture(WGPUCommandEncoder commandEncoder, WGPUImageCopyTexture const * source, WGPUImageCopyTexture const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
+static inline void gowebgpu_command_encoder_copy_texture_to_texture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderCopyTextureToTexture(commandEncoder, source, destination, copySize);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline WGPUCommandBuffer gowebgpu_command_encoder_finish(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor, WGPUDevice device, void * error_userdata) {
 	WGPUCommandBuffer ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuCommandEncoderFinish(commandEncoder, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
 static inline void gowebgpu_command_encoder_insert_debug_marker(WGPUCommandEncoder commandEncoder, char const * markerLabel, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
-	wgpuCommandEncoderInsertDebugMarker(commandEncoder, markerLabel);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+	wgpuCommandEncoderInsertDebugMarker(commandEncoder, (WGPUStringView) {markerLabel, WGPU_STRLEN});
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_pop_debug_group(WGPUCommandEncoder commandEncoder, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderPopDebugGroup(commandEncoder);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_push_debug_group(WGPUCommandEncoder commandEncoder, char const * groupLabel, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
-	wgpuCommandEncoderPushDebugGroup(commandEncoder, groupLabel);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+	wgpuCommandEncoderPushDebugGroup(commandEncoder, (WGPUStringView) {groupLabel, WGPU_STRLEN});
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_resolve_query_set(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderResolveQuerySet(commandEncoder, querySet, firstQuery, queryCount, destination, destinationOffset);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_write_timestamp(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t queryIndex, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuCommandEncoderWriteTimestamp(commandEncoder, querySet, queryIndex);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_command_encoder_release(WGPUCommandEncoder commandEncoder, WGPUDevice device) {
@@ -119,7 +186,7 @@ func (p *CommandEncoder) BeginComputePass(descriptor *ComputePassDescriptor) *Co
 		panic("Failed to acquire ComputePassEncoder")
 	}
 
-	C.wgpuDeviceReference(p.deviceRef)
+	C.wgpuDeviceAddRef(p.deviceRef)
 	return &ComputePassEncoder{deviceRef: p.deviceRef, ref: ref}
 }
 
@@ -188,7 +255,7 @@ func (p *CommandEncoder) BeginRenderPass(descriptor *RenderPassDescriptor) *Rend
 	}
 
 	ref := C.wgpuCommandEncoderBeginRenderPass(p.ref, &desc)
-	C.wgpuDeviceReference(p.deviceRef)
+	C.wgpuDeviceAddRef(p.deviceRef)
 	return &RenderPassEncoder{deviceRef: p.deviceRef, ref: ref}
 }
 
@@ -230,22 +297,22 @@ func (p *CommandEncoder) CopyBufferToBuffer(source *Buffer, sourceOffset uint64,
 	return
 }
 
-func (p *CommandEncoder) CopyBufferToTexture(source *ImageCopyBuffer, destination *ImageCopyTexture, copySize *Extent3D) (err error) {
-	var src C.WGPUImageCopyBuffer
+func (p *CommandEncoder) CopyBufferToTexture(source *TexelCopyBufferInfo, destination *TexelCopyTextureInfo, copySize *Extent3D) (err error) {
+	var src C.WGPUTexelCopyBufferInfo
 	if source != nil {
 		if source.Buffer != nil {
 			src.buffer = source.Buffer.ref
 		}
-		src.layout = C.WGPUTextureDataLayout{
+		src.layout = C.WGPUTexelCopyBufferLayout{
 			offset:       C.uint64_t(source.Layout.Offset),
 			bytesPerRow:  C.uint32_t(source.Layout.BytesPerRow),
 			rowsPerImage: C.uint32_t(source.Layout.RowsPerImage),
 		}
 	}
 
-	var dst C.WGPUImageCopyTexture
+	var dst C.WGPUTexelCopyTextureInfo
 	if destination != nil {
-		dst = C.WGPUImageCopyTexture{
+		dst = C.WGPUTexelCopyTextureInfo{
 			mipLevel: C.uint32_t(destination.MipLevel),
 			origin: C.WGPUOrigin3D{
 				x: C.uint32_t(destination.Origin.X),
@@ -285,10 +352,10 @@ func (p *CommandEncoder) CopyBufferToTexture(source *ImageCopyBuffer, destinatio
 	return
 }
 
-func (p *CommandEncoder) CopyTextureToBuffer(source *ImageCopyTexture, destination *ImageCopyBuffer, copySize *Extent3D) (err error) {
-	var src C.WGPUImageCopyTexture
+func (p *CommandEncoder) CopyTextureToBuffer(source *TexelCopyTextureInfo, destination *TexelCopyBufferInfo, copySize *Extent3D) (err error) {
+	var src C.WGPUTexelCopyTextureInfo
 	if source != nil {
-		src = C.WGPUImageCopyTexture{
+		src = C.WGPUTexelCopyTextureInfo{
 			mipLevel: C.uint32_t(source.MipLevel),
 			origin: C.WGPUOrigin3D{
 				x: C.uint32_t(source.Origin.X),
@@ -302,12 +369,12 @@ func (p *CommandEncoder) CopyTextureToBuffer(source *ImageCopyTexture, destinati
 		}
 	}
 
-	var dst C.WGPUImageCopyBuffer
+	var dst C.WGPUTexelCopyBufferInfo
 	if destination != nil {
 		if destination.Buffer != nil {
 			dst.buffer = destination.Buffer.ref
 		}
-		dst.layout = C.WGPUTextureDataLayout{
+		dst.layout = C.WGPUTexelCopyBufferLayout{
 			offset:       C.uint64_t(destination.Layout.Offset),
 			bytesPerRow:  C.uint32_t(destination.Layout.BytesPerRow),
 			rowsPerImage: C.uint32_t(destination.Layout.RowsPerImage),
@@ -340,10 +407,10 @@ func (p *CommandEncoder) CopyTextureToBuffer(source *ImageCopyTexture, destinati
 	return
 }
 
-func (p *CommandEncoder) CopyTextureToTexture(source *ImageCopyTexture, destination *ImageCopyTexture, copySize *Extent3D) (err error) {
-	var src C.WGPUImageCopyTexture
+func (p *CommandEncoder) CopyTextureToTexture(source *TexelCopyTextureInfo, destination *TexelCopyTextureInfo, copySize *Extent3D) (err error) {
+	var src C.WGPUTexelCopyTextureInfo
 	if source != nil {
-		src = C.WGPUImageCopyTexture{
+		src = C.WGPUTexelCopyTextureInfo{
 			mipLevel: C.uint32_t(source.MipLevel),
 			origin: C.WGPUOrigin3D{
 				x: C.uint32_t(source.Origin.X),
@@ -357,9 +424,9 @@ func (p *CommandEncoder) CopyTextureToTexture(source *ImageCopyTexture, destinat
 		}
 	}
 
-	var dst C.WGPUImageCopyTexture
+	var dst C.WGPUTexelCopyTextureInfo
 	if destination != nil {
-		dst = C.WGPUImageCopyTexture{
+		dst = C.WGPUTexelCopyTextureInfo{
 			mipLevel: C.uint32_t(destination.MipLevel),
 			origin: C.WGPUOrigin3D{
 				x: C.uint32_t(destination.Origin.X),

--- a/wgpu/command_encoder.go
+++ b/wgpu/command_encoder.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 

--- a/wgpu/command_encoder.go
+++ b/wgpu/command_encoder.go
@@ -177,7 +177,7 @@ func (p *CommandEncoder) BeginComputePass(descriptor *ComputePassDescriptor) *Co
 		defer C.free(unsafe.Pointer(label))
 
 		desc = &C.WGPUComputePassDescriptor{
-			label: label,
+			label: C.WGPUStringView{data: label, length: C.WGPU_STRLEN},
 		}
 	}
 
@@ -198,7 +198,8 @@ func (p *CommandEncoder) BeginRenderPass(descriptor *RenderPassDescriptor) *Rend
 			label := C.CString(descriptor.Label)
 			defer C.free(unsafe.Pointer(label))
 
-			desc.label = label
+			desc.label.data = label
+			desc.label.length = C.WGPU_STRLEN
 		}
 
 		colorAttachmentCount := len(descriptor.ColorAttachments)
@@ -474,7 +475,7 @@ func (p *CommandEncoder) Finish(descriptor *CommandBufferDescriptor) (*CommandBu
 		defer C.free(unsafe.Pointer(label))
 
 		desc = &C.WGPUCommandBufferDescriptor{
-			label: label,
+			label: C.WGPUStringView{data: label, length: C.WGPU_STRLEN},
 		}
 	}
 

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -101,7 +101,6 @@ type Extent3D struct {
 type InstanceDescriptor struct {
 	Backends           InstanceBackend
 	Dx12ShaderCompiler Dx12Compiler
-	DxilPath           string
 	DxcPath            string
 }
 

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -124,8 +124,12 @@ type SurfaceCapabilities struct {
 	AlphaModes   []CompositeAlphaMode
 }
 
-type ShaderModuleWGSLDescriptor struct {
+type ShaderSourceWGSL struct {
 	Code string
+}
+
+type ShaderSourceSPIRV struct {
+	Code []byte
 }
 
 type DeviceDescriptor struct {

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -79,7 +79,7 @@ type SurfaceConfiguration struct {
 	ViewFormats []TextureFormat
 }
 
-type ImageCopyTexture struct {
+type TexelCopyTextureInfo struct {
 	Texture  *Texture
 	MipLevel uint32
 	Origin   Origin3D
@@ -165,7 +165,7 @@ type BufferInitDescriptor struct {
 	Usage    BufferUsage
 }
 
-type BufferMapCallback func(BufferMapAsyncStatus)
+type BufferMapCallback func(MapAsyncStatus)
 
 type QueueWorkDoneCallback func(QueueWorkDoneStatus)
 
@@ -234,14 +234,9 @@ type CommandBufferDescriptor struct {
 	Label string
 }
 
-type WrappedSubmissionIndex struct {
-	Queue           *Queue
-	SubmissionIndex SubmissionIndex
-}
-
 type SubmissionIndex uint64
 
-type ImageCopyBuffer struct {
+type TexelCopyBufferInfo struct {
 	Layout TextureDataLayout
 	Buffer *Buffer
 }

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -86,7 +86,7 @@ type TexelCopyTextureInfo struct {
 	Aspect   TextureAspect
 }
 
-type TextureDataLayout struct {
+type TexelCopyBufferLayout struct {
 	Offset       uint64
 	BytesPerRow  uint32
 	RowsPerImage uint32
@@ -241,7 +241,7 @@ type CommandBufferDescriptor struct {
 type SubmissionIndex uint64
 
 type TexelCopyBufferInfo struct {
-	Layout TextureDataLayout
+	Layout TexelCopyBufferLayout
 	Buffer *Buffer
 }
 

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -53,11 +53,8 @@ type Limits struct {
 	MaxComputeWorkgroupSizeZ                  uint32
 	MaxComputeWorkgroupsPerDimension          uint32
 
-	MaxPushConstantSize uint32
-}
-
-type SupportedLimits struct {
-	Limits Limits
+	MaxPushConstantSize   uint32
+	MaxNonSamplerBindings uint32
 }
 
 // Color as described:
@@ -131,14 +128,10 @@ type ShaderModuleWGSLDescriptor struct {
 	Code string
 }
 
-type RequiredLimits struct {
-	Limits Limits
-}
-
 type DeviceDescriptor struct {
 	Label              string
 	RequiredFeatures   []FeatureName
-	RequiredLimits     *RequiredLimits
+	RequiredLimits     *Limits
 	DeviceLostCallback DeviceLostCallback
 	TracePath          string
 }

--- a/wgpu/common.go
+++ b/wgpu/common.go
@@ -246,14 +246,14 @@ type TexelCopyBufferInfo struct {
 }
 
 type AdapterInfo struct {
-	VendorId          uint32
-	VendorName        string
-	Architecture      string
-	DeviceId          uint32
-	Name              string
-	DriverDescription string
-	AdapterType       AdapterType
-	BackendType       BackendType
+	Vendor       string
+	Architecture string
+	Device       string
+	Description  string
+	AdapterType  AdapterType
+	BackendType  BackendType
+	VendorId     uint32
+	DeviceId     uint32
 }
 
 type SamplerDescriptor struct {

--- a/wgpu/compute_pass_encoder.go
+++ b/wgpu/compute_pass_encoder.go
@@ -70,7 +70,10 @@ func (p *ComputePassEncoder) InsertDebugMarker(markerLabel string) {
 	markerLabelStr := C.CString(markerLabel)
 	defer C.free(unsafe.Pointer(markerLabelStr))
 
-	C.wgpuComputePassEncoderInsertDebugMarker(p.ref, markerLabelStr)
+	C.wgpuComputePassEncoderInsertDebugMarker(p.ref, C.WGPUStringView{
+		data: markerLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *ComputePassEncoder) PopDebugGroup() {
@@ -81,7 +84,10 @@ func (p *ComputePassEncoder) PushDebugGroup(groupLabel string) {
 	groupLabelStr := C.CString(groupLabel)
 	defer C.free(unsafe.Pointer(groupLabelStr))
 
-	C.wgpuComputePassEncoderPushDebugGroup(p.ref, groupLabelStr)
+	C.wgpuComputePassEncoderPushDebugGroup(p.ref, C.WGPUStringView{
+		data: groupLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *ComputePassEncoder) SetBindGroup(groupIndex uint32, group *BindGroup, dynamicOffsets []uint32) {

--- a/wgpu/compute_pass_encoder.go
+++ b/wgpu/compute_pass_encoder.go
@@ -7,12 +7,18 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
 static inline void gowebgpu_compute_pass_encoder_end(WGPUComputePassEncoder computePassEncoder, WGPUDevice device, void * error_userdata) {
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuComputePassEncoderEnd(computePassEncoder);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
 }
 
 static inline void gowebgpu_compute_pass_encoder_release(WGPUComputePassEncoder computePassEncoder, WGPUDevice device) {

--- a/wgpu/compute_pass_encoder.go
+++ b/wgpu/compute_pass_encoder.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
@@ -71,7 +71,7 @@ func (p *ComputePassEncoder) InsertDebugMarker(markerLabel string) {
 	defer C.free(unsafe.Pointer(markerLabelStr))
 
 	C.wgpuComputePassEncoderInsertDebugMarker(p.ref, C.WGPUStringView{
-		data: markerLabelStr,
+		data:   markerLabelStr,
 		length: C.WGPU_STRLEN,
 	})
 }
@@ -85,7 +85,7 @@ func (p *ComputePassEncoder) PushDebugGroup(groupLabel string) {
 	defer C.free(unsafe.Pointer(groupLabelStr))
 
 	C.wgpuComputePassEncoderPushDebugGroup(p.ref, C.WGPUStringView{
-		data: groupLabelStr,
+		data:   groupLabelStr,
 		length: C.WGPU_STRLEN,
 	})
 }

--- a/wgpu/compute_pipeline.go
+++ b/wgpu/compute_pipeline.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 */
 import "C"

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -1284,6 +1284,7 @@ func (p *Device) HasFeature(feature FeatureName) bool {
 	return goBool(hasFeature)
 }
 
-func (p *Device) Poll(wait bool, submissionIndex uint64) (queueEmpty bool) {
-	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), (*C.WGPUSubmissionIndex)(unsafe.Pointer(&submissionIndex))))
+func (p *Device) Poll(wait bool, submissionIndex *uint64) (queueEmpty bool) {
+	var index *C.WGPUSubmissionIndex
+	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), index))
 }

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -178,6 +178,7 @@ static inline WGPUTexture gowebgpu_device_create_texture(WGPUDevice device, WGPU
 import "C"
 import (
 	"errors"
+	"fmt"
 	"runtime/cgo"
 	"unsafe"
 )
@@ -190,6 +191,10 @@ type errorCallback func(typ ErrorType, message string)
 
 //export gowebgpu_error_callback_go
 func gowebgpu_error_callback_go(_type C.WGPUErrorType, message *C.WGPUStringView, userdata unsafe.Pointer) {
+	if userdata == nil {
+		fmt.Println("Warning: nil userdata in error callback:", C.GoStringN(message.data, C.int(message.length)))
+		return
+	}
 	handle := *(*cgo.Handle)(userdata)
 	cb, ok := handle.Value().(errorCallback)
 	if ok {

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -757,14 +757,6 @@ type StencilFaceState struct {
 	PassOp      StencilOperation
 }
 
-type OptionalBool uint32
-
-const (
-	False     OptionalBool = C.WGPUOptionalBool_False
-	True      OptionalBool = C.WGPUOptionalBool_True
-	Undefined OptionalBool = C.WGPUOptionalBool_Undefined
-)
-
 type DepthStencilState struct {
 	Format              TextureFormat
 	DepthWriteEnabled   OptionalBool

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -189,11 +189,11 @@ type Device struct {
 type errorCallback func(typ ErrorType, message string)
 
 //export gowebgpu_error_callback_go
-func gowebgpu_error_callback_go(_type C.WGPUErrorType, message *C.char, userdata unsafe.Pointer) {
+func gowebgpu_error_callback_go(_type C.WGPUErrorType, message *C.WGPUStringView, userdata unsafe.Pointer) {
 	handle := *(*cgo.Handle)(userdata)
 	cb, ok := handle.Value().(errorCallback)
 	if ok {
-		cb(ErrorType(_type), C.GoString(message))
+		cb(ErrorType(_type), C.GoStringN(message.data, message.length))
 	}
 }
 

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -178,7 +178,6 @@ static inline WGPUTexture gowebgpu_device_create_texture(WGPUDevice device, WGPU
 import "C"
 import (
 	"errors"
-	"fmt"
 	"runtime/cgo"
 	"unsafe"
 )
@@ -190,11 +189,7 @@ type Device struct {
 type errorCallback func(typ ErrorType, message string)
 
 //export gowebgpu_error_callback_go
-func gowebgpu_error_callback_go(_type C.WGPUErrorType, message *C.WGPUStringView, userdata unsafe.Pointer) {
-	if userdata == nil {
-		fmt.Println("Warning: nil userdata in error callback:", C.GoStringN(message.data, C.int(message.length)))
-		return
-	}
+func gowebgpu_error_callback_go(_type C.WGPUErrorType, message C.WGPUStringView, userdata unsafe.Pointer) {
 	handle := *(*cgo.Handle)(userdata)
 	cb, ok := handle.Value().(errorCallback)
 	if ok {

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -7,13 +7,20 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
 static inline WGPUBindGroup gowebgpu_device_create_bind_group(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor, void * error_userdata) {
 	WGPUBindGroup ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateBindGroup(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -21,7 +28,14 @@ static inline WGPUBindGroupLayout gowebgpu_device_create_bind_group_layout(WGPUD
 	WGPUBindGroupLayout ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateBindGroupLayout(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -29,7 +43,14 @@ static inline WGPUBuffer gowebgpu_device_create_buffer(WGPUDevice device, WGPUBu
 	WGPUBuffer ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateBuffer(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -37,7 +58,14 @@ static inline WGPUCommandEncoder gowebgpu_device_create_command_encoder(WGPUDevi
 	WGPUCommandEncoder ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateCommandEncoder(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -45,7 +73,14 @@ static inline WGPUComputePipeline gowebgpu_device_create_compute_pipeline(WGPUDe
 	WGPUComputePipeline ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateComputePipeline(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -53,7 +88,14 @@ static inline WGPUPipelineLayout gowebgpu_device_create_pipeline_layout(WGPUDevi
 	WGPUPipelineLayout ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreatePipelineLayout(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -61,7 +103,14 @@ static inline WGPUQuerySet gowebgpu_device_create_query_set(WGPUDevice device, W
 	WGPUQuerySet ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateQuerySet(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -69,7 +118,14 @@ static inline WGPURenderPipeline gowebgpu_device_create_render_pipeline(WGPUDevi
 	WGPURenderPipeline ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateRenderPipeline(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -77,7 +133,14 @@ static inline WGPUSampler gowebgpu_device_create_sampler(WGPUDevice device, WGPU
 	WGPUSampler ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateSampler(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -85,7 +148,14 @@ static inline WGPUShaderModule gowebgpu_device_create_shader_module(WGPUDevice d
 	WGPUShaderModule ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateShaderModule(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -93,7 +163,14 @@ static inline WGPUTexture gowebgpu_device_create_texture(WGPUDevice device, WGPU
 	WGPUTexture ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuDeviceCreateTexture(device, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 
@@ -242,7 +319,7 @@ func (p *Device) CreateBindGroupLayout(descriptor *BindGroupLayoutDescriptor) (*
 				entriesSlice[i] = C.WGPUBindGroupLayoutEntry{
 					nextInChain: nil,
 					binding:     C.uint32_t(v.Binding),
-					visibility:  C.WGPUShaderStageFlags(v.Visibility),
+					visibility:  C.WGPUShaderStage(v.Visibility),
 					buffer: C.WGPUBufferBindingLayout{
 						nextInChain:      nil,
 						_type:            C.WGPUBufferBindingType(v.Buffer.Type),
@@ -304,7 +381,7 @@ func (p *Device) CreateBuffer(descriptor *BufferDescriptor) (*Buffer, error) {
 			desc.label = label
 		}
 
-		desc.usage = C.WGPUBufferUsageFlags(descriptor.Usage)
+		desc.usage = C.WGPUBufferUsage(descriptor.Usage)
 		desc.size = C.uint64_t(descriptor.Size)
 		desc.mappedAtCreation = cBool(descriptor.MappedAtCreation)
 	}
@@ -326,7 +403,7 @@ func (p *Device) CreateBuffer(descriptor *BufferDescriptor) (*Buffer, error) {
 		return nil, err
 	}
 
-	C.wgpuDeviceReference(p.ref)
+	C.wgpuDeviceAddRef(p.ref)
 	return &Buffer{deviceRef: p.ref, ref: ref}, nil
 }
 
@@ -359,7 +436,7 @@ func (p *Device) CreateCommandEncoder(descriptor *CommandEncoderDescriptor) (*Co
 		return nil, err
 	}
 
-	C.wgpuDeviceReference(p.ref)
+	C.wgpuDeviceAddRef(p.ref)
 	return &CommandEncoder{deviceRef: p.ref, ref: ref}, nil
 }
 
@@ -475,7 +552,7 @@ func (p *Device) CreatePipelineLayout(descriptor *PipelineLayoutDescriptor) (*Pi
 
 			for i, v := range descriptor.PushConstantRanges {
 				pushConstantRangesSlice[i] = C.WGPUPushConstantRange{
-					stages: C.WGPUShaderStageFlags(v.Stages),
+					stages: C.WGPUShaderStage(v.Stages),
 					start:  C.uint32_t(v.Start),
 					end:    C.uint32_t(v.End),
 				}
@@ -832,7 +909,7 @@ func (p *Device) CreateRenderPipeline(descriptor *RenderPipelineDescriptor) (*Re
 				for i, v := range fragment.Targets {
 					target := C.WGPUColorTargetState{
 						format:    C.WGPUTextureFormat(v.Format),
-						writeMask: C.WGPUColorWriteMaskFlags(v.WriteMask),
+						writeMask: C.WGPUColorWriteMask(v.WriteMask),
 					}
 
 					if v.Blend != nil {
@@ -863,7 +940,7 @@ func (p *Device) CreateRenderPipeline(descriptor *RenderPipelineDescriptor) (*Re
 				frag.targets = nil
 			}
 			frag.constantCount = 0 // note: crashes on linux arm64 without setting this to 0
-			frag.constants = nil // even though wgpu doesn't even support it.
+			frag.constants = nil   // even though wgpu doesn't even support it.
 
 			desc.fragment = frag
 		}
@@ -1076,7 +1153,7 @@ func (p *Device) CreateTexture(descriptor *TextureDescriptor) (*Texture, error) 
 
 	if descriptor != nil {
 		desc = C.WGPUTextureDescriptor{
-			usage:     C.WGPUTextureUsageFlags(descriptor.Usage),
+			usage:     C.WGPUTextureUsage(descriptor.Usage),
 			dimension: C.WGPUTextureDimension(descriptor.Dimension),
 			size: C.WGPUExtent3D{
 				width:              C.uint32_t(descriptor.Size.Width),
@@ -1113,72 +1190,70 @@ func (p *Device) CreateTexture(descriptor *TextureDescriptor) (*Texture, error) 
 		return nil, err
 	}
 
-	C.wgpuDeviceReference(p.ref)
+	C.wgpuDeviceAddRef(p.ref)
 	return &Texture{deviceRef: p.ref, ref: ref}, nil
 }
 
-func (p *Device) EnumerateFeatures() []FeatureName {
-	size := C.wgpuDeviceEnumerateFeatures(p.ref, nil)
+func (p *Device) GetFeatures() []FeatureName {
+	size := C.wgpuDeviceGetFeatures(p.ref, nil)
 	if size == 0 {
 		return nil
 	}
 
 	features := make([]FeatureName, size)
-	C.wgpuDeviceEnumerateFeatures(p.ref, (*C.WGPUFeatureName)(unsafe.Pointer(&features[0])))
+	C.wgpuDeviceGetFeatures(p.ref, (*C.WGPUFeatureName)(unsafe.Pointer(&features[0])))
 	return features
 }
 
-func (p *Device) GetLimits() SupportedLimits {
-	var supportedLimits C.WGPUSupportedLimits
+func (p *Device) GetLimits() Limits {
+	var limits C.WGPULimits
 
-	extras := (*C.WGPUSupportedLimitsExtras)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSupportedLimitsExtras{}))))
-	defer C.free(unsafe.Pointer(extras))
-	supportedLimits.nextInChain = (*C.WGPUChainedStructOut)(unsafe.Pointer(extras))
+	nativeLimits := (*C.WGPUNativeLimits)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUNativeLimits{}))))
+	defer C.free(unsafe.Pointer(&nativeLimits))
+	limits.nextInChain = (*C.WGPUChainedStructOut)(unsafe.Pointer(&nativeLimits))
 
-	C.wgpuDeviceGetLimits(p.ref, &supportedLimits)
+	C.wgpuDeviceGetLimits(p.ref, &limits)
 
-	limits := supportedLimits.limits
-	return SupportedLimits{
-		Limits{
-			MaxTextureDimension1D:                     uint32(limits.maxTextureDimension1D),
-			MaxTextureDimension2D:                     uint32(limits.maxTextureDimension2D),
-			MaxTextureDimension3D:                     uint32(limits.maxTextureDimension3D),
-			MaxTextureArrayLayers:                     uint32(limits.maxTextureArrayLayers),
-			MaxBindGroups:                             uint32(limits.maxBindGroups),
-			MaxBindingsPerBindGroup:                   uint32(limits.maxBindingsPerBindGroup),
-			MaxDynamicUniformBuffersPerPipelineLayout: uint32(limits.maxDynamicUniformBuffersPerPipelineLayout),
-			MaxDynamicStorageBuffersPerPipelineLayout: uint32(limits.maxDynamicStorageBuffersPerPipelineLayout),
-			MaxSampledTexturesPerShaderStage:          uint32(limits.maxSampledTexturesPerShaderStage),
-			MaxSamplersPerShaderStage:                 uint32(limits.maxSamplersPerShaderStage),
-			MaxStorageBuffersPerShaderStage:           uint32(limits.maxStorageBuffersPerShaderStage),
-			MaxStorageTexturesPerShaderStage:          uint32(limits.maxStorageTexturesPerShaderStage),
-			MaxUniformBuffersPerShaderStage:           uint32(limits.maxUniformBuffersPerShaderStage),
-			MaxUniformBufferBindingSize:               uint64(limits.maxUniformBufferBindingSize),
-			MaxStorageBufferBindingSize:               uint64(limits.maxStorageBufferBindingSize),
-			MinUniformBufferOffsetAlignment:           uint32(limits.minUniformBufferOffsetAlignment),
-			MinStorageBufferOffsetAlignment:           uint32(limits.minStorageBufferOffsetAlignment),
-			MaxVertexBuffers:                          uint32(limits.maxVertexBuffers),
-			MaxBufferSize:                             uint64(limits.maxBufferSize),
-			MaxVertexAttributes:                       uint32(limits.maxVertexAttributes),
-			MaxVertexBufferArrayStride:                uint32(limits.maxVertexBufferArrayStride),
-			MaxInterStageShaderComponents:             uint32(limits.maxInterStageShaderComponents),
-			MaxInterStageShaderVariables:              uint32(limits.maxInterStageShaderVariables),
-			MaxColorAttachments:                       uint32(limits.maxColorAttachments),
-			MaxComputeWorkgroupStorageSize:            uint32(limits.maxComputeWorkgroupStorageSize),
-			MaxComputeInvocationsPerWorkgroup:         uint32(limits.maxComputeInvocationsPerWorkgroup),
-			MaxComputeWorkgroupSizeX:                  uint32(limits.maxComputeWorkgroupSizeX),
-			MaxComputeWorkgroupSizeY:                  uint32(limits.maxComputeWorkgroupSizeY),
-			MaxComputeWorkgroupSizeZ:                  uint32(limits.maxComputeWorkgroupSizeZ),
-			MaxComputeWorkgroupsPerDimension:          uint32(limits.maxComputeWorkgroupsPerDimension),
+	return Limits{
+		MaxTextureDimension1D:                     uint32(limits.maxTextureDimension1D),
+		MaxTextureDimension2D:                     uint32(limits.maxTextureDimension2D),
+		MaxTextureDimension3D:                     uint32(limits.maxTextureDimension3D),
+		MaxTextureArrayLayers:                     uint32(limits.maxTextureArrayLayers),
+		MaxBindGroups:                             uint32(limits.maxBindGroups),
+		MaxBindingsPerBindGroup:                   uint32(limits.maxBindingsPerBindGroup),
+		MaxDynamicUniformBuffersPerPipelineLayout: uint32(limits.maxDynamicUniformBuffersPerPipelineLayout),
+		MaxDynamicStorageBuffersPerPipelineLayout: uint32(limits.maxDynamicStorageBuffersPerPipelineLayout),
+		MaxSampledTexturesPerShaderStage:          uint32(limits.maxSampledTexturesPerShaderStage),
+		MaxSamplersPerShaderStage:                 uint32(limits.maxSamplersPerShaderStage),
+		MaxStorageBuffersPerShaderStage:           uint32(limits.maxStorageBuffersPerShaderStage),
+		MaxStorageTexturesPerShaderStage:          uint32(limits.maxStorageTexturesPerShaderStage),
+		MaxUniformBuffersPerShaderStage:           uint32(limits.maxUniformBuffersPerShaderStage),
+		MaxUniformBufferBindingSize:               uint64(limits.maxUniformBufferBindingSize),
+		MaxStorageBufferBindingSize:               uint64(limits.maxStorageBufferBindingSize),
+		MinUniformBufferOffsetAlignment:           uint32(limits.minUniformBufferOffsetAlignment),
+		MinStorageBufferOffsetAlignment:           uint32(limits.minStorageBufferOffsetAlignment),
+		MaxVertexBuffers:                          uint32(limits.maxVertexBuffers),
+		MaxBufferSize:                             uint64(limits.maxBufferSize),
+		MaxVertexAttributes:                       uint32(limits.maxVertexAttributes),
+		MaxVertexBufferArrayStride:                uint32(limits.maxVertexBufferArrayStride),
+		MaxInterStageShaderComponents:             uint32(limits.maxInterStageShaderComponents),
+		MaxInterStageShaderVariables:              uint32(limits.maxInterStageShaderVariables),
+		MaxColorAttachments:                       uint32(limits.maxColorAttachments),
+		MaxComputeWorkgroupStorageSize:            uint32(limits.maxComputeWorkgroupStorageSize),
+		MaxComputeInvocationsPerWorkgroup:         uint32(limits.maxComputeInvocationsPerWorkgroup),
+		MaxComputeWorkgroupSizeX:                  uint32(limits.maxComputeWorkgroupSizeX),
+		MaxComputeWorkgroupSizeY:                  uint32(limits.maxComputeWorkgroupSizeY),
+		MaxComputeWorkgroupSizeZ:                  uint32(limits.maxComputeWorkgroupSizeZ),
+		MaxComputeWorkgroupsPerDimension:          uint32(limits.maxComputeWorkgroupsPerDimension),
 
-			MaxPushConstantSize: uint32(extras.limits.maxPushConstantSize),
-		},
+		MaxPushConstantSize:   uint32(nativeLimits.maxPushConstantSize),
+		MaxNonSamplerBindings: uint32(nativeLimits.maxNonSamplerBindings),
 	}
 }
 
 func (p *Device) GetQueue() *Queue {
 	ref := C.wgpuDeviceGetQueue(p.ref)
-	C.wgpuDeviceReference(p.ref)
+	C.wgpuDeviceAddRef(p.ref)
 	return &Queue{deviceRef: p.ref, ref: ref}
 }
 
@@ -1187,14 +1262,6 @@ func (p *Device) HasFeature(feature FeatureName) bool {
 	return goBool(hasFeature)
 }
 
-func (p *Device) Poll(wait bool, wrappedSubmissionIndex *WrappedSubmissionIndex) (queueEmpty bool) {
-	var index *C.WGPUWrappedSubmissionIndex
-	if wrappedSubmissionIndex != nil {
-		index = &C.WGPUWrappedSubmissionIndex{
-			queue:           wrappedSubmissionIndex.Queue.ref,
-			submissionIndex: C.WGPUSubmissionIndex(wrappedSubmissionIndex.SubmissionIndex),
-		}
-	}
-
-	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), index))
+func (p *Device) Poll(wait bool, submissionIndex uint64) (queueEmpty bool) {
+	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), submissionIndex))
 }

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -1285,6 +1285,5 @@ func (p *Device) HasFeature(feature FeatureName) bool {
 }
 
 func (p *Device) Poll(wait bool, submissionIndex *uint64) (queueEmpty bool) {
-	var index *C.WGPUSubmissionIndex
-	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), index))
+	return goBool(C.wgpuDevicePoll(p.ref, cBool(wait), (*C.WGPUSubmissionIndex)(submissionIndex)))
 }

--- a/wgpu/enums.go
+++ b/wgpu/enums.go
@@ -5,10 +5,10 @@ package wgpu
 type AdapterType uint32
 
 const (
-	AdapterTypeDiscreteGPU   AdapterType = 0x00000000
-	AdapterTypeIntegratedGPU AdapterType = 0x00000001
-	AdapterTypeCPU           AdapterType = 0x00000002
-	AdapterTypeUnknown       AdapterType = 0x00000003
+	AdapterTypeDiscreteGPU   AdapterType = 0x00000001
+	AdapterTypeIntegratedGPU AdapterType = 0x00000002
+	AdapterTypeCPU           AdapterType = 0x00000003
+	AdapterTypeUnknown       AdapterType = 0x00000004
 )
 
 func (v AdapterType) String() string {
@@ -29,19 +29,22 @@ func (v AdapterType) String() string {
 type AddressMode uint32
 
 const (
-	AddressModeRepeat       AddressMode = 0x00000000
-	AddressModeMirrorRepeat AddressMode = 0x00000001
-	AddressModeClampToEdge  AddressMode = 0x00000002
+	AddressModeUndefined    AddressMode = 0x00000000
+	AddressModeClampToEdge  AddressMode = 0x00000001
+	AddressModeRepeat       AddressMode = 0x00000002
+	AddressModeMirrorRepeat AddressMode = 0x00000003
 )
 
 func (v AddressMode) String() string {
 	switch v {
+	case AddressModeUndefined:
+		return "undefined"
+	case AddressModeClampToEdge:
+		return "clamp-to-edge"
 	case AddressModeRepeat:
 		return "repeat"
 	case AddressModeMirrorRepeat:
 		return "mirror-repeat"
-	case AddressModeClampToEdge:
-		return "clamp-to-edge"
 	default:
 		return ""
 	}
@@ -89,23 +92,30 @@ func (v BackendType) String() string {
 type BlendFactor uint32
 
 const (
-	BlendFactorZero              BlendFactor = 0x00000000
-	BlendFactorOne               BlendFactor = 0x00000001
-	BlendFactorSrc               BlendFactor = 0x00000002
-	BlendFactorOneMinusSrc       BlendFactor = 0x00000003
-	BlendFactorSrcAlpha          BlendFactor = 0x00000004
-	BlendFactorOneMinusSrcAlpha  BlendFactor = 0x00000005
-	BlendFactorDst               BlendFactor = 0x00000006
-	BlendFactorOneMinusDst       BlendFactor = 0x00000007
-	BlendFactorDstAlpha          BlendFactor = 0x00000008
-	BlendFactorOneMinusDstAlpha  BlendFactor = 0x00000009
-	BlendFactorSrcAlphaSaturated BlendFactor = 0x0000000A
-	BlendFactorConstant          BlendFactor = 0x0000000B
-	BlendFactorOneMinusConstant  BlendFactor = 0x0000000C
+	BlendFactorUndefined         BlendFactor = 0x00000000
+	BlendFactorZero              BlendFactor = 0x00000001
+	BlendFactorOne               BlendFactor = 0x00000002
+	BlendFactorSrc               BlendFactor = 0x00000003
+	BlendFactorOneMinusSrc       BlendFactor = 0x00000004
+	BlendFactorSrcAlpha          BlendFactor = 0x00000005
+	BlendFactorOneMinusSrcAlpha  BlendFactor = 0x00000006
+	BlendFactorDst               BlendFactor = 0x00000007
+	BlendFactorOneMinusDst       BlendFactor = 0x00000008
+	BlendFactorDstAlpha          BlendFactor = 0x00000009
+	BlendFactorOneMinusDstAlpha  BlendFactor = 0x0000000A
+	BlendFactorSrcAlphaSaturated BlendFactor = 0x0000000B
+	BlendFactorConstant          BlendFactor = 0x0000000C
+	BlendFactorOneMinusConstant  BlendFactor = 0x0000000D
+	BlendFactorSrc1              BlendFactor = 0x0000000E
+	BlendFactorOneMinusSrc1      BlendFactor = 0x0000000F
+	BlendFactorSrc1Alpha         BlendFactor = 0x00000010
+	BlendFactorOneMinusSrc1Alpha BlendFactor = 0x00000011
 )
 
 func (v BlendFactor) String() string {
 	switch v {
+	case BlendFactorUndefined:
+		return "undefined"
 	case BlendFactorZero:
 		return "zero"
 	case BlendFactorOne:
@@ -132,6 +142,14 @@ func (v BlendFactor) String() string {
 		return "constant"
 	case BlendFactorOneMinusConstant:
 		return "one-minus-constant"
+	case BlendFactorSrc1:
+		return "src1"
+	case BlendFactorOneMinusSrc1:
+		return "one-minus-src1"
+	case BlendFactorSrc1Alpha:
+		return "src1alpha"
+	case BlendFactorOneMinusSrc1Alpha:
+		return "one-minus-src1alpha"
 	default:
 		return ""
 	}
@@ -140,15 +158,18 @@ func (v BlendFactor) String() string {
 type BlendOperation uint32
 
 const (
-	BlendOperationAdd             BlendOperation = 0x00000000
-	BlendOperationSubtract        BlendOperation = 0x00000001
-	BlendOperationReverseSubtract BlendOperation = 0x00000002
-	BlendOperationMin             BlendOperation = 0x00000003
-	BlendOperationMax             BlendOperation = 0x00000004
+	BlendOperationUndefined       BlendOperation = 0x00000000
+	BlendOperationAdd             BlendOperation = 0x00000001
+	BlendOperationSubtract        BlendOperation = 0x00000002
+	BlendOperationReverseSubtract BlendOperation = 0x00000003
+	BlendOperationMin             BlendOperation = 0x00000004
+	BlendOperationMax             BlendOperation = 0x00000005
 )
 
 func (v BlendOperation) String() string {
 	switch v {
+	case BlendOperationUndefined:
+		return "undefined"
 	case BlendOperationAdd:
 		return "add"
 	case BlendOperationSubtract:
@@ -167,14 +188,17 @@ func (v BlendOperation) String() string {
 type BufferBindingType uint32
 
 const (
-	BufferBindingTypeUndefined       BufferBindingType = 0x00000000
-	BufferBindingTypeUniform         BufferBindingType = 0x00000001
-	BufferBindingTypeStorage         BufferBindingType = 0x00000002
-	BufferBindingTypeReadOnlyStorage BufferBindingType = 0x00000003
+	BufferBindingTypeBindingNotUsed  BufferBindingType = 0x00000000
+	BufferBindingTypeUndefined       BufferBindingType = 0x00000001
+	BufferBindingTypeUniform         BufferBindingType = 0x00000002
+	BufferBindingTypeStorage         BufferBindingType = 0x00000003
+	BufferBindingTypeReadOnlyStorage BufferBindingType = 0x00000004
 )
 
 func (v BufferBindingType) String() string {
 	switch v {
+	case BufferBindingTypeBindingNotUsed:
+		return "binding-not-used"
 	case BufferBindingTypeUndefined:
 		return "undefined"
 	case BufferBindingTypeUniform:
@@ -188,51 +212,12 @@ func (v BufferBindingType) String() string {
 	}
 }
 
-type MapAsyncStatus uint32
-
-const (
-	MapAsyncStatusSuccess                 MapAsyncStatus = 0x00000000
-	MapAsyncStatusValidationError         MapAsyncStatus = 0x00000001
-	MapAsyncStatusUnknown                 MapAsyncStatus = 0x00000002
-	MapAsyncStatusDeviceLost              MapAsyncStatus = 0x00000003
-	MapAsyncStatusDestroyedBeforeCallback MapAsyncStatus = 0x00000004
-	MapAsyncStatusUnmappedBeforeCallback  MapAsyncStatus = 0x00000005
-	MapAsyncStatusMappingAlreadyPending   MapAsyncStatus = 0x00000006
-	MapAsyncStatusOffsetOutOfRange        MapAsyncStatus = 0x00000007
-	MapAsyncStatusSizeOutOfRange          MapAsyncStatus = 0x00000008
-)
-
-func (v MapAsyncStatus) String() string {
-	switch v {
-	case MapAsyncStatusSuccess:
-		return "success"
-	case MapAsyncStatusValidationError:
-		return "validation-error"
-	case MapAsyncStatusUnknown:
-		return "unknown"
-	case MapAsyncStatusDeviceLost:
-		return "device-lost"
-	case MapAsyncStatusDestroyedBeforeCallback:
-		return "destroyed-before-callback"
-	case MapAsyncStatusUnmappedBeforeCallback:
-		return "unmapped-before-callback"
-	case MapAsyncStatusMappingAlreadyPending:
-		return "mapping-already-pending"
-	case MapAsyncStatusOffsetOutOfRange:
-		return "offset-out-of-range"
-	case MapAsyncStatusSizeOutOfRange:
-		return "size-out-of-range"
-	default:
-		return ""
-	}
-}
-
 type BufferMapState uint32
 
 const (
-	BufferMapStateUnmapped BufferMapState = 0x00000000
-	BufferMapStatePending  BufferMapState = 0x00000001
-	BufferMapStateMapped   BufferMapState = 0x00000002
+	BufferMapStateUnmapped BufferMapState = 0x00000001
+	BufferMapStatePending  BufferMapState = 0x00000002
+	BufferMapStateMapped   BufferMapState = 0x00000003
 )
 
 func (v BufferMapState) String() string {
@@ -248,76 +233,22 @@ func (v BufferMapState) String() string {
 	}
 }
 
-type BufferUsage uint32
+type CallbackMode uint32
 
 const (
-	BufferUsageNone         BufferUsage = 0x00000000
-	BufferUsageMapRead      BufferUsage = 0x00000001
-	BufferUsageMapWrite     BufferUsage = 0x00000002
-	BufferUsageCopySrc      BufferUsage = 0x00000004
-	BufferUsageCopyDst      BufferUsage = 0x00000008
-	BufferUsageIndex        BufferUsage = 0x00000010
-	BufferUsageVertex       BufferUsage = 0x00000020
-	BufferUsageUniform      BufferUsage = 0x00000040
-	BufferUsageStorage      BufferUsage = 0x00000080
-	BufferUsageIndirect     BufferUsage = 0x00000100
-	BufferUsageQueryResolve BufferUsage = 0x00000200
+	CallbackModeWaitAnyOnly        CallbackMode = 0x00000001
+	CallbackModeAllowProcessEvents CallbackMode = 0x00000002
+	CallbackModeAllowSpontaneous   CallbackMode = 0x00000003
 )
 
-func (v BufferUsage) String() string {
+func (v CallbackMode) String() string {
 	switch v {
-	case BufferUsageNone:
-		return "none"
-	case BufferUsageMapRead:
-		return "map-read"
-	case BufferUsageMapWrite:
-		return "map-write"
-	case BufferUsageCopySrc:
-		return "copy-src"
-	case BufferUsageCopyDst:
-		return "copy-dst"
-	case BufferUsageIndex:
-		return "index"
-	case BufferUsageVertex:
-		return "vertex"
-	case BufferUsageUniform:
-		return "uniform"
-	case BufferUsageStorage:
-		return "storage"
-	case BufferUsageIndirect:
-		return "indirect"
-	case BufferUsageQueryResolve:
-		return "query-resolve"
-	default:
-		return ""
-	}
-}
-
-type ColorWriteMask uint32
-
-const (
-	ColorWriteMaskNone  ColorWriteMask = 0x00000000
-	ColorWriteMaskRed   ColorWriteMask = 0x00000001
-	ColorWriteMaskGreen ColorWriteMask = 0x00000002
-	ColorWriteMaskBlue  ColorWriteMask = 0x00000004
-	ColorWriteMaskAlpha ColorWriteMask = 0x00000008
-	ColorWriteMaskAll   ColorWriteMask = 0x0000000F
-)
-
-func (v ColorWriteMask) String() string {
-	switch v {
-	case ColorWriteMaskNone:
-		return "none"
-	case ColorWriteMaskRed:
-		return "red"
-	case ColorWriteMaskGreen:
-		return "green"
-	case ColorWriteMaskBlue:
-		return "blue"
-	case ColorWriteMaskAlpha:
-		return "alpha"
-	case ColorWriteMaskAll:
-		return "all"
+	case CallbackModeWaitAnyOnly:
+		return "wait-any-only"
+	case CallbackModeAllowProcessEvents:
+		return "allow-process-events"
+	case CallbackModeAllowSpontaneous:
+		return "allow-spontaneous"
 	default:
 		return ""
 	}
@@ -329,11 +260,11 @@ const (
 	CompareFunctionUndefined    CompareFunction = 0x00000000
 	CompareFunctionNever        CompareFunction = 0x00000001
 	CompareFunctionLess         CompareFunction = 0x00000002
-	CompareFunctionLessEqual    CompareFunction = 0x00000003
-	CompareFunctionGreater      CompareFunction = 0x00000004
-	CompareFunctionGreaterEqual CompareFunction = 0x00000005
-	CompareFunctionEqual        CompareFunction = 0x00000006
-	CompareFunctionNotEqual     CompareFunction = 0x00000007
+	CompareFunctionEqual        CompareFunction = 0x00000003
+	CompareFunctionLessEqual    CompareFunction = 0x00000004
+	CompareFunctionGreater      CompareFunction = 0x00000005
+	CompareFunctionNotEqual     CompareFunction = 0x00000006
+	CompareFunctionGreaterEqual CompareFunction = 0x00000007
 	CompareFunctionAlways       CompareFunction = 0x00000008
 )
 
@@ -345,16 +276,16 @@ func (v CompareFunction) String() string {
 		return "never"
 	case CompareFunctionLess:
 		return "less"
+	case CompareFunctionEqual:
+		return "equal"
 	case CompareFunctionLessEqual:
 		return "less-equal"
 	case CompareFunctionGreater:
 		return "greater"
-	case CompareFunctionGreaterEqual:
-		return "greater-equal"
-	case CompareFunctionEqual:
-		return "equal"
 	case CompareFunctionNotEqual:
 		return "not-equal"
+	case CompareFunctionGreaterEqual:
+		return "greater-equal"
 	case CompareFunctionAlways:
 		return "always"
 	default:
@@ -365,20 +296,20 @@ func (v CompareFunction) String() string {
 type CompilationInfoRequestStatus uint32
 
 const (
-	CompilationInfoRequestStatusSuccess    CompilationInfoRequestStatus = 0x00000000
-	CompilationInfoRequestStatusError      CompilationInfoRequestStatus = 0x00000001
-	CompilationInfoRequestStatusDeviceLost CompilationInfoRequestStatus = 0x00000002
-	CompilationInfoRequestStatusUnknown    CompilationInfoRequestStatus = 0x00000003
+	CompilationInfoRequestStatusSuccess         CompilationInfoRequestStatus = 0x00000001
+	CompilationInfoRequestStatusInstanceDropped CompilationInfoRequestStatus = 0x00000002
+	CompilationInfoRequestStatusError           CompilationInfoRequestStatus = 0x00000003
+	CompilationInfoRequestStatusUnknown         CompilationInfoRequestStatus = 0x00000004
 )
 
 func (v CompilationInfoRequestStatus) String() string {
 	switch v {
 	case CompilationInfoRequestStatusSuccess:
 		return "success"
+	case CompilationInfoRequestStatusInstanceDropped:
+		return "instance-dropped"
 	case CompilationInfoRequestStatusError:
 		return "error"
-	case CompilationInfoRequestStatusDeviceLost:
-		return "device-lost"
 	case CompilationInfoRequestStatusUnknown:
 		return "unknown"
 	default:
@@ -389,9 +320,9 @@ func (v CompilationInfoRequestStatus) String() string {
 type CompilationMessageType uint32
 
 const (
-	CompilationMessageTypeError   CompilationMessageType = 0x00000000
-	CompilationMessageTypeWarning CompilationMessageType = 0x00000001
-	CompilationMessageTypeInfo    CompilationMessageType = 0x00000002
+	CompilationMessageTypeError   CompilationMessageType = 0x00000001
+	CompilationMessageTypeWarning CompilationMessageType = 0x00000002
+	CompilationMessageTypeInfo    CompilationMessageType = 0x00000003
 )
 
 func (v CompilationMessageType) String() string {
@@ -437,11 +368,10 @@ func (v CompositeAlphaMode) String() string {
 type CreatePipelineAsyncStatus uint32
 
 const (
-	CreatePipelineAsyncStatusSuccess         CreatePipelineAsyncStatus = 0x00000000
-	CreatePipelineAsyncStatusValidationError CreatePipelineAsyncStatus = 0x00000001
-	CreatePipelineAsyncStatusInternalError   CreatePipelineAsyncStatus = 0x00000002
-	CreatePipelineAsyncStatusDeviceLost      CreatePipelineAsyncStatus = 0x00000003
-	CreatePipelineAsyncStatusDeviceDestroyed CreatePipelineAsyncStatus = 0x00000004
+	CreatePipelineAsyncStatusSuccess         CreatePipelineAsyncStatus = 0x00000001
+	CreatePipelineAsyncStatusInstanceDropped CreatePipelineAsyncStatus = 0x00000002
+	CreatePipelineAsyncStatusValidationError CreatePipelineAsyncStatus = 0x00000003
+	CreatePipelineAsyncStatusInternalError   CreatePipelineAsyncStatus = 0x00000004
 	CreatePipelineAsyncStatusUnknown         CreatePipelineAsyncStatus = 0x00000005
 )
 
@@ -449,14 +379,12 @@ func (v CreatePipelineAsyncStatus) String() string {
 	switch v {
 	case CreatePipelineAsyncStatusSuccess:
 		return "success"
+	case CreatePipelineAsyncStatusInstanceDropped:
+		return "instance-dropped"
 	case CreatePipelineAsyncStatusValidationError:
 		return "validation-error"
 	case CreatePipelineAsyncStatusInternalError:
 		return "internal-error"
-	case CreatePipelineAsyncStatusDeviceLost:
-		return "device-lost"
-	case CreatePipelineAsyncStatusDeviceDestroyed:
-		return "device-destroyed"
 	case CreatePipelineAsyncStatusUnknown:
 		return "unknown"
 	default:
@@ -467,13 +395,16 @@ func (v CreatePipelineAsyncStatus) String() string {
 type CullMode uint32
 
 const (
-	CullModeNone  CullMode = 0x00000000
-	CullModeFront CullMode = 0x00000001
-	CullModeBack  CullMode = 0x00000002
+	CullModeUndefined CullMode = 0x00000000
+	CullModeNone      CullMode = 0x00000001
+	CullModeFront     CullMode = 0x00000002
+	CullModeBack      CullMode = 0x00000003
 )
 
 func (v CullMode) String() string {
 	switch v {
+	case CullModeUndefined:
+		return "undefined"
 	case CullModeNone:
 		return "none"
 	case CullModeFront:
@@ -488,8 +419,10 @@ func (v CullMode) String() string {
 type DeviceLostReason uint32
 
 const (
-	DeviceLostReasonUnknown   DeviceLostReason = 0x00000001
-	DeviceLostReasonDestroyed DeviceLostReason = 0x00000002
+	DeviceLostReasonUnknown         DeviceLostReason = 0x00000001
+	DeviceLostReasonDestroyed       DeviceLostReason = 0x00000002
+	DeviceLostReasonInstanceDropped DeviceLostReason = 0x00000003
+	DeviceLostReasonFailedCreation  DeviceLostReason = 0x00000004
 )
 
 func (v DeviceLostReason) String() string {
@@ -498,6 +431,10 @@ func (v DeviceLostReason) String() string {
 		return "unknown"
 	case DeviceLostReasonDestroyed:
 		return "destroyed"
+	case DeviceLostReasonInstanceDropped:
+		return "instance-dropped"
+	case DeviceLostReasonFailedCreation:
+		return "failed-creation"
 	default:
 		return ""
 	}
@@ -527,9 +464,9 @@ func (v Dx12Compiler) String() string {
 type ErrorFilter uint32
 
 const (
-	ErrorFilterValidation  ErrorFilter = 0x00000000
-	ErrorFilterOutOfMemory ErrorFilter = 0x00000001
-	ErrorFilterInternal    ErrorFilter = 0x00000002
+	ErrorFilterValidation  ErrorFilter = 0x00000001
+	ErrorFilterOutOfMemory ErrorFilter = 0x00000002
+	ErrorFilterInternal    ErrorFilter = 0x00000003
 )
 
 func (v ErrorFilter) String() string {
@@ -548,12 +485,11 @@ func (v ErrorFilter) String() string {
 type ErrorType uint32
 
 const (
-	ErrorTypeNoError     ErrorType = 0x00000000
-	ErrorTypeValidation  ErrorType = 0x00000001
-	ErrorTypeOutOfMemory ErrorType = 0x00000002
-	ErrorTypeInternal    ErrorType = 0x00000003
-	ErrorTypeUnknown     ErrorType = 0x00000004
-	ErrorTypeDeviceLost  ErrorType = 0x00000005
+	ErrorTypeNoError     ErrorType = 0x00000001
+	ErrorTypeValidation  ErrorType = 0x00000002
+	ErrorTypeOutOfMemory ErrorType = 0x00000003
+	ErrorTypeInternal    ErrorType = 0x00000004
+	ErrorTypeUnknown     ErrorType = 0x00000005
 )
 
 func (v ErrorType) String() string {
@@ -568,10 +504,26 @@ func (v ErrorType) String() string {
 		return "internal"
 	case ErrorTypeUnknown:
 		return "unknown"
-	case ErrorTypeDeviceLost:
-		return "device-lost"
 	default:
 		return "unknown"
+	}
+}
+
+type FeatureLevel uint32
+
+const (
+	FeatureLevelCompatibility FeatureLevel = 0x00000001
+	FeatureLevelCore          FeatureLevel = 0x00000002
+)
+
+func (v FeatureLevel) String() string {
+	switch v {
+	case FeatureLevelCompatibility:
+		return "compatibility"
+	case FeatureLevelCore:
+		return "core"
+	default:
+		return ""
 	}
 }
 
@@ -583,13 +535,18 @@ const (
 	FeatureNameDepth32FloatStencil8                                    FeatureName = 0x00000002
 	FeatureNameTimestampQuery                                          FeatureName = 0x00000003
 	FeatureNameTextureCompressionBC                                    FeatureName = 0x00000004
-	FeatureNameTextureCompressionETC2                                  FeatureName = 0x00000005
-	FeatureNameTextureCompressionASTC                                  FeatureName = 0x00000006
-	FeatureNameIndirectFirstInstance                                   FeatureName = 0x00000007
-	FeatureNameShaderF16                                               FeatureName = 0x00000008
-	FeatureNameRG11B10UfloatRenderable                                 FeatureName = 0x00000009
-	FeatureNameBGRA8UnormStorage                                       FeatureName = 0x0000000A
-	FeatureNameFloat32Filterable                                       FeatureName = 0x0000000B
+	FeatureNameTextureCompressionBCSliced3D                            FeatureName = 0x00000005
+	FeatureNameTextureCompressionETC2                                  FeatureName = 0x00000006
+	FeatureNameTextureCompressionASTC                                  FeatureName = 0x00000007
+	FeatureNameTextureCompressionASTCSliced3D                          FeatureName = 0x00000008
+	FeatureNameIndirectFirstInstance                                   FeatureName = 0x00000009
+	FeatureNameShaderF16                                               FeatureName = 0x0000000A
+	FeatureNameRG11B10UfloatRenderable                                 FeatureName = 0x0000000B
+	FeatureNameBGRA8UnormStorage                                       FeatureName = 0x0000000C
+	FeatureNameFloat32Filterable                                       FeatureName = 0x0000000D
+	FeatureNameFloat32Blendable                                        FeatureName = 0x0000000E
+	FeatureNameClipDistances                                           FeatureName = 0x0000000F
+	FeatureNameDualSourceBlending                                      FeatureName = 0x00000010
 	NativeFeaturePushConstants                                         FeatureName = 0x00030001
 	NativeFeatureTextureAdapterSpecificFormatFeatures                  FeatureName = 0x00030002
 	NativeFeatureMultiDrawIndirect                                     FeatureName = 0x00030003
@@ -605,15 +562,20 @@ const (
 	NativeFeatureMappablePrimaryBuffers                                FeatureName = 0x0003000E
 	NativeFeatureBufferBindingArray                                    FeatureName = 0x0003000F
 	NativeFeatureUniformBufferAndStorageTextureArrayNonUniformIndexing FeatureName = 0x00030010
+	NativeFeatureSpirvShaderPassthrough                                FeatureName = 0x00030017
 	NativeFeatureVertexAttribute64bit                                  FeatureName = 0x00030019
-	NativeFeatureShaderUnusedVertexOutput                              FeatureName = 0x0003001A
-	NativeFeatureTextureFormatNv12                                     FeatureName = 0x0003001B
-	NativeFeatureRayTracingAccelerationStructure                       FeatureName = 0x0003001C
-	NativeFeatureRayQuery                                              FeatureName = 0x0003001D
-	NativeFeatureShaderF64                                             FeatureName = 0x0003001E
-	NativeFeatureShaderI16                                             FeatureName = 0x0003001F
-	NativeFeatureShaderPrimitiveIndex                                  FeatureName = 0x00030020
-	NativeFeatureShaderEarlyDepthTest                                  FeatureName = 0x00030021
+	NativeFeatureTextureFormatNv12                                     FeatureName = 0x0003001A
+	NativeFeatureRayTracingAccelerationStructure                       FeatureName = 0x0003001B
+	NativeFeatureRayQuery                                              FeatureName = 0x0003001C
+	NativeFeatureShaderF64                                             FeatureName = 0x0003001D
+	NativeFeatureShaderI16                                             FeatureName = 0x0003001E
+	NativeFeatureShaderPrimitiveIndex                                  FeatureName = 0x0003001F
+	NativeFeatureShaderEarlyDepthTest                                  FeatureName = 0x00030020
+	NativeFeatureSubgroup                                              FeatureName = 0x00030021
+	NativeFeatureSubgroupVertex                                        FeatureName = 0x00030022
+	NativeFeatureSubgroupBarrier                                       FeatureName = 0x00030023
+	NativeFeatureTimestampQueryInsideEncoders                          FeatureName = 0x00030024
+	NativeFeatureTimestampQueryInsidePasses                            FeatureName = 0x00030025
 )
 
 func (v FeatureName) String() string {
@@ -628,10 +590,14 @@ func (v FeatureName) String() string {
 		return "timestamp-query"
 	case FeatureNameTextureCompressionBC:
 		return "texture-compression-bc"
+	case FeatureNameTextureCompressionBCSliced3D:
+		return "texture-compression-bc-sliced3d"
 	case FeatureNameTextureCompressionETC2:
 		return "texture-compression-etc2"
 	case FeatureNameTextureCompressionASTC:
 		return "texture-compression-astc"
+	case FeatureNameTextureCompressionASTCSliced3D:
+		return "texture-compression-astc-sliced3d"
 	case FeatureNameIndirectFirstInstance:
 		return "indirect-first-instance"
 	case FeatureNameShaderF16:
@@ -642,6 +608,12 @@ func (v FeatureName) String() string {
 		return "bgra8unorm-storage"
 	case FeatureNameFloat32Filterable:
 		return "float32filterable"
+	case FeatureNameFloat32Blendable:
+		return "float32blendable"
+	case FeatureNameClipDistances:
+		return "clip-distances"
+	case FeatureNameDualSourceBlending:
+		return "dual-source-blending"
 	case NativeFeaturePushConstants:
 		return "native-feature-push-constants"
 	case NativeFeatureTextureAdapterSpecificFormatFeatures:
@@ -672,10 +644,10 @@ func (v FeatureName) String() string {
 		return "native-feature-buffer-binding-array"
 	case NativeFeatureUniformBufferAndStorageTextureArrayNonUniformIndexing:
 		return "native-feature-uniform-buffer-and-storage-texture-array-non-uniform-indexing"
+	case NativeFeatureSpirvShaderPassthrough:
+		return "native-feature-spirv-shader-passthrough"
 	case NativeFeatureVertexAttribute64bit:
 		return "native-feature-vertex-attribute64bit"
-	case NativeFeatureShaderUnusedVertexOutput:
-		return "native-feature-shader-unused-vertex-output"
 	case NativeFeatureTextureFormatNv12:
 		return "native-feature-texture-format-nv12"
 	case NativeFeatureRayTracingAccelerationStructure:
@@ -690,6 +662,16 @@ func (v FeatureName) String() string {
 		return "native-feature-shader-primitive-index"
 	case NativeFeatureShaderEarlyDepthTest:
 		return "native-feature-shader-early-depth-test"
+	case NativeFeatureSubgroup:
+		return "native-feature-subgroup"
+	case NativeFeatureSubgroupVertex:
+		return "native-feature-subgroup-vertex"
+	case NativeFeatureSubgroupBarrier:
+		return "native-feature-subgroup-barrier"
+	case NativeFeatureTimestampQueryInsideEncoders:
+		return "native-feature-timestamp-query-inside-encoders"
+	case NativeFeatureTimestampQueryInsidePasses:
+		return "native-feature-timestamp-query-inside-passes"
 	default:
 		return ""
 	}
@@ -698,12 +680,15 @@ func (v FeatureName) String() string {
 type FilterMode uint32
 
 const (
-	FilterModeNearest FilterMode = 0x00000000
-	FilterModeLinear  FilterMode = 0x00000001
+	FilterModeUndefined FilterMode = 0x00000000
+	FilterModeNearest   FilterMode = 0x00000001
+	FilterModeLinear    FilterMode = 0x00000002
 )
 
 func (v FilterMode) String() string {
 	switch v {
+	case FilterModeUndefined:
+		return "undefined"
 	case FilterModeNearest:
 		return "nearest"
 	case FilterModeLinear:
@@ -716,12 +701,15 @@ func (v FilterMode) String() string {
 type FrontFace uint32
 
 const (
-	FrontFaceCCW FrontFace = 0x00000000
-	FrontFaceCW  FrontFace = 0x00000001
+	FrontFaceUndefined FrontFace = 0x00000000
+	FrontFaceCCW       FrontFace = 0x00000001
+	FrontFaceCW        FrontFace = 0x00000002
 )
 
 func (v FrontFace) String() string {
 	switch v {
+	case FrontFaceUndefined:
+		return "undefined"
 	case FrontFaceCCW:
 		return "ccw"
 	case FrontFaceCW:
@@ -776,85 +764,22 @@ func (v IndexFormat) String() string {
 	}
 }
 
-type InstanceBackend uint32
-
-const (
-	InstanceBackendAll           InstanceBackend = 0x00000000
-	InstanceBackendVulkan        InstanceBackend = 0x00000001
-	InstanceBackendGL            InstanceBackend = 0x00000002
-	InstanceBackendMetal         InstanceBackend = 0x00000004
-	InstanceBackendDX12          InstanceBackend = 0x00000008
-	InstanceBackendDX11          InstanceBackend = 0x00000010
-	InstanceBackendSecondary     InstanceBackend = 0x00000012
-	InstanceBackendBrowserWebGPU InstanceBackend = 0x00000020
-	InstanceBackendPrimary       InstanceBackend = 0x0000002D
-)
-
-func (v InstanceBackend) String() string {
-	switch v {
-	case InstanceBackendAll:
-		return "all"
-	case InstanceBackendVulkan:
-		return "vulkan"
-	case InstanceBackendGL:
-		return "gl"
-	case InstanceBackendMetal:
-		return "metal"
-	case InstanceBackendDX12:
-		return "dx12"
-	case InstanceBackendDX11:
-		return "dx11"
-	case InstanceBackendSecondary:
-		return "secondary"
-	case InstanceBackendBrowserWebGPU:
-		return "browser-web-gpu"
-	case InstanceBackendPrimary:
-		return "primary"
-	default:
-		return ""
-	}
-}
-
-type InstanceFlag uint32
-
-const (
-	InstanceFlagDefault          InstanceFlag = 0x00000000
-	InstanceFlagDebug            InstanceFlag = 0x00000001
-	InstanceFlagValidation       InstanceFlag = 0x00000002
-	InstanceFlagDiscardHalLabels InstanceFlag = 0x00000004
-)
-
-func (v InstanceFlag) String() string {
-	switch v {
-	case InstanceFlagDefault:
-		return "default"
-	case InstanceFlagDebug:
-		return "debug"
-	case InstanceFlagValidation:
-		return "validation"
-	case InstanceFlagDiscardHalLabels:
-		return "discard-hal-labels"
-	default:
-		return ""
-	}
-}
-
 type LoadOp uint32
 
 const (
 	LoadOpUndefined LoadOp = 0x00000000
-	LoadOpClear     LoadOp = 0x00000001
-	LoadOpLoad      LoadOp = 0x00000002
+	LoadOpLoad      LoadOp = 0x00000001
+	LoadOpClear     LoadOp = 0x00000002
 )
 
 func (v LoadOp) String() string {
 	switch v {
 	case LoadOpUndefined:
 		return "undefined"
-	case LoadOpClear:
-		return "clear"
 	case LoadOpLoad:
 		return "load"
+	case LoadOpClear:
+		return "clear"
 	default:
 		return ""
 	}
@@ -890,22 +815,28 @@ func (v LogLevel) String() string {
 	}
 }
 
-type MapMode uint32
+type MapAsyncStatus uint32
 
 const (
-	MapModeNone  MapMode = 0x00000000
-	MapModeRead  MapMode = 0x00000001
-	MapModeWrite MapMode = 0x00000002
+	MapAsyncStatusSuccess         MapAsyncStatus = 0x00000001
+	MapAsyncStatusInstanceDropped MapAsyncStatus = 0x00000002
+	MapAsyncStatusError           MapAsyncStatus = 0x00000003
+	MapAsyncStatusAborted         MapAsyncStatus = 0x00000004
+	MapAsyncStatusUnknown         MapAsyncStatus = 0x00000005
 )
 
-func (v MapMode) String() string {
+func (v MapAsyncStatus) String() string {
 	switch v {
-	case MapModeNone:
-		return "none"
-	case MapModeRead:
-		return "read"
-	case MapModeWrite:
-		return "write"
+	case MapAsyncStatusSuccess:
+		return "success"
+	case MapAsyncStatusInstanceDropped:
+		return "instance-dropped"
+	case MapAsyncStatusError:
+		return "error"
+	case MapAsyncStatusAborted:
+		return "aborted"
+	case MapAsyncStatusUnknown:
+		return "unknown"
 	default:
 		return ""
 	}
@@ -914,12 +845,15 @@ func (v MapMode) String() string {
 type MipmapFilterMode uint32
 
 const (
-	MipmapFilterModeNearest MipmapFilterMode = 0x00000000
-	MipmapFilterModeLinear  MipmapFilterMode = 0x00000001
+	MipmapFilterModeUndefined MipmapFilterMode = 0x00000000
+	MipmapFilterModeNearest   MipmapFilterMode = 0x00000001
+	MipmapFilterModeLinear    MipmapFilterMode = 0x00000002
 )
 
 func (v MipmapFilterMode) String() string {
 	switch v {
+	case MipmapFilterModeUndefined:
+		return "undefined"
 	case MipmapFilterModeNearest:
 		return "nearest"
 	case MipmapFilterModeLinear:
@@ -975,6 +909,27 @@ func (v NativeTextureFormat) String() string {
 	}
 }
 
+type OptionalBool uint32
+
+const (
+	OptionalBoolFalse     OptionalBool = 0x00000000
+	OptionalBoolTrue      OptionalBool = 0x00000001
+	OptionalBoolUndefined OptionalBool = 0x00000002
+)
+
+func (v OptionalBool) String() string {
+	switch v {
+	case OptionalBoolFalse:
+		return "false"
+	case OptionalBoolTrue:
+		return "true"
+	case OptionalBoolUndefined:
+		return "undefined"
+	default:
+		return ""
+	}
+}
+
 type PipelineStatisticName uint32
 
 const (
@@ -997,6 +952,27 @@ func (v PipelineStatisticName) String() string {
 		return "fragment-shader-invocations"
 	case PipelineStatisticNameComputeShaderInvocations:
 		return "compute-shader-invocations"
+	default:
+		return ""
+	}
+}
+
+type PopErrorScopeStatus uint32
+
+const (
+	PopErrorScopeStatusSuccess         PopErrorScopeStatus = 0x00000001
+	PopErrorScopeStatusInstanceDropped PopErrorScopeStatus = 0x00000002
+	PopErrorScopeStatusEmptyStack      PopErrorScopeStatus = 0x00000003
+)
+
+func (v PopErrorScopeStatus) String() string {
+	switch v {
+	case PopErrorScopeStatusSuccess:
+		return "success"
+	case PopErrorScopeStatusInstanceDropped:
+		return "instance-dropped"
+	case PopErrorScopeStatusEmptyStack:
+		return "empty-stack"
 	default:
 		return ""
 	}
@@ -1026,14 +1002,17 @@ func (v PowerPreference) String() string {
 type PresentMode uint32
 
 const (
-	PresentModeFifo        PresentMode = 0x00000000
-	PresentModeFifoRelaxed PresentMode = 0x00000001
-	PresentModeImmediate   PresentMode = 0x00000002
-	PresentModeMailbox     PresentMode = 0x00000003
+	PresentModeUndefined   PresentMode = 0x00000000
+	PresentModeFifo        PresentMode = 0x00000001
+	PresentModeFifoRelaxed PresentMode = 0x00000002
+	PresentModeImmediate   PresentMode = 0x00000003
+	PresentModeMailbox     PresentMode = 0x00000004
 )
 
 func (v PresentMode) String() string {
 	switch v {
+	case PresentModeUndefined:
+		return "undefined"
 	case PresentModeFifo:
 		return "fifo"
 	case PresentModeFifoRelaxed:
@@ -1050,15 +1029,18 @@ func (v PresentMode) String() string {
 type PrimitiveTopology uint32
 
 const (
-	PrimitiveTopologyPointList     PrimitiveTopology = 0x00000000
-	PrimitiveTopologyLineList      PrimitiveTopology = 0x00000001
-	PrimitiveTopologyLineStrip     PrimitiveTopology = 0x00000002
-	PrimitiveTopologyTriangleList  PrimitiveTopology = 0x00000003
-	PrimitiveTopologyTriangleStrip PrimitiveTopology = 0x00000004
+	PrimitiveTopologyUndefined     PrimitiveTopology = 0x00000000
+	PrimitiveTopologyPointList     PrimitiveTopology = 0x00000001
+	PrimitiveTopologyLineList      PrimitiveTopology = 0x00000002
+	PrimitiveTopologyLineStrip     PrimitiveTopology = 0x00000003
+	PrimitiveTopologyTriangleList  PrimitiveTopology = 0x00000004
+	PrimitiveTopologyTriangleStrip PrimitiveTopology = 0x00000005
 )
 
 func (v PrimitiveTopology) String() string {
 	switch v {
+	case PrimitiveTopologyUndefined:
+		return "undefined"
 	case PrimitiveTopologyPointList:
 		return "point-list"
 	case PrimitiveTopologyLineList:
@@ -1077,8 +1059,8 @@ func (v PrimitiveTopology) String() string {
 type QueryType uint32
 
 const (
-	QueryTypeOcclusion QueryType = 0x00000000
-	QueryTypeTimestamp QueryType = 0x00000001
+	QueryTypeOcclusion QueryType = 0x00000001
+	QueryTypeTimestamp QueryType = 0x00000002
 )
 
 func (v QueryType) String() string {
@@ -1095,22 +1077,22 @@ func (v QueryType) String() string {
 type QueueWorkDoneStatus uint32
 
 const (
-	QueueWorkDoneStatusSuccess    QueueWorkDoneStatus = 0x00000000
-	QueueWorkDoneStatusError      QueueWorkDoneStatus = 0x00000001
-	QueueWorkDoneStatusUnknown    QueueWorkDoneStatus = 0x00000002
-	QueueWorkDoneStatusDeviceLost QueueWorkDoneStatus = 0x00000003
+	QueueWorkDoneStatusSuccess         QueueWorkDoneStatus = 0x00000001
+	QueueWorkDoneStatusInstanceDropped QueueWorkDoneStatus = 0x00000002
+	QueueWorkDoneStatusError           QueueWorkDoneStatus = 0x00000003
+	QueueWorkDoneStatusUnknown         QueueWorkDoneStatus = 0x00000004
 )
 
 func (v QueueWorkDoneStatus) String() string {
 	switch v {
 	case QueueWorkDoneStatusSuccess:
 		return "success"
+	case QueueWorkDoneStatusInstanceDropped:
+		return "instance-dropped"
 	case QueueWorkDoneStatusError:
 		return "error"
 	case QueueWorkDoneStatusUnknown:
 		return "unknown"
-	case QueueWorkDoneStatusDeviceLost:
-		return "device-lost"
 	default:
 		return ""
 	}
@@ -1119,16 +1101,19 @@ func (v QueueWorkDoneStatus) String() string {
 type RequestAdapterStatus uint32
 
 const (
-	RequestAdapterStatusSuccess     RequestAdapterStatus = 0x00000000
-	RequestAdapterStatusUnavailable RequestAdapterStatus = 0x00000001
-	RequestAdapterStatusError       RequestAdapterStatus = 0x00000002
-	RequestAdapterStatusUnknown     RequestAdapterStatus = 0x00000003
+	RequestAdapterStatusSuccess         RequestAdapterStatus = 0x00000001
+	RequestAdapterStatusInstanceDropped RequestAdapterStatus = 0x00000002
+	RequestAdapterStatusUnavailable     RequestAdapterStatus = 0x00000003
+	RequestAdapterStatusError           RequestAdapterStatus = 0x00000004
+	RequestAdapterStatusUnknown         RequestAdapterStatus = 0x00000005
 )
 
 func (v RequestAdapterStatus) String() string {
 	switch v {
 	case RequestAdapterStatusSuccess:
 		return "success"
+	case RequestAdapterStatusInstanceDropped:
+		return "instance-dropped"
 	case RequestAdapterStatusUnavailable:
 		return "unavailable"
 	case RequestAdapterStatusError:
@@ -1143,15 +1128,18 @@ func (v RequestAdapterStatus) String() string {
 type RequestDeviceStatus uint32
 
 const (
-	RequestDeviceStatusSuccess RequestDeviceStatus = 0x00000000
-	RequestDeviceStatusError   RequestDeviceStatus = 0x00000001
-	RequestDeviceStatusUnknown RequestDeviceStatus = 0x00000002
+	RequestDeviceStatusSuccess         RequestDeviceStatus = 0x00000001
+	RequestDeviceStatusInstanceDropped RequestDeviceStatus = 0x00000002
+	RequestDeviceStatusError           RequestDeviceStatus = 0x00000003
+	RequestDeviceStatusUnknown         RequestDeviceStatus = 0x00000004
 )
 
 func (v RequestDeviceStatus) String() string {
 	switch v {
 	case RequestDeviceStatusSuccess:
 		return "success"
+	case RequestDeviceStatusInstanceDropped:
+		return "instance-dropped"
 	case RequestDeviceStatusError:
 		return "error"
 	case RequestDeviceStatusUnknown:
@@ -1164,14 +1152,17 @@ func (v RequestDeviceStatus) String() string {
 type SamplerBindingType uint32
 
 const (
-	SamplerBindingTypeUndefined    SamplerBindingType = 0x00000000
-	SamplerBindingTypeFiltering    SamplerBindingType = 0x00000001
-	SamplerBindingTypeNonFiltering SamplerBindingType = 0x00000002
-	SamplerBindingTypeComparison   SamplerBindingType = 0x00000003
+	SamplerBindingTypeBindingNotUsed SamplerBindingType = 0x00000000
+	SamplerBindingTypeUndefined      SamplerBindingType = 0x00000001
+	SamplerBindingTypeFiltering      SamplerBindingType = 0x00000002
+	SamplerBindingTypeNonFiltering   SamplerBindingType = 0x00000003
+	SamplerBindingTypeComparison     SamplerBindingType = 0x00000004
 )
 
 func (v SamplerBindingType) String() string {
 	switch v {
+	case SamplerBindingTypeBindingNotUsed:
+		return "binding-not-used"
 	case SamplerBindingTypeUndefined:
 		return "undefined"
 	case SamplerBindingTypeFiltering:
@@ -1185,25 +1176,19 @@ func (v SamplerBindingType) String() string {
 	}
 }
 
-type ShaderStage uint32
+type Status uint32
 
 const (
-	ShaderStageNone     ShaderStage = 0x00000000
-	ShaderStageVertex   ShaderStage = 0x00000001
-	ShaderStageFragment ShaderStage = 0x00000002
-	ShaderStageCompute  ShaderStage = 0x00000004
+	StatusSuccess Status = 0x00000001
+	StatusError   Status = 0x00000002
 )
 
-func (v ShaderStage) String() string {
+func (v Status) String() string {
 	switch v {
-	case ShaderStageNone:
-		return "none"
-	case ShaderStageVertex:
-		return "vertex"
-	case ShaderStageFragment:
-		return "fragment"
-	case ShaderStageCompute:
-		return "compute"
+	case StatusSuccess:
+		return "success"
+	case StatusError:
+		return "error"
 	default:
 		return ""
 	}
@@ -1212,18 +1197,21 @@ func (v ShaderStage) String() string {
 type StencilOperation uint32
 
 const (
-	StencilOperationKeep           StencilOperation = 0x00000000
-	StencilOperationZero           StencilOperation = 0x00000001
-	StencilOperationReplace        StencilOperation = 0x00000002
-	StencilOperationInvert         StencilOperation = 0x00000003
-	StencilOperationIncrementClamp StencilOperation = 0x00000004
-	StencilOperationDecrementClamp StencilOperation = 0x00000005
-	StencilOperationIncrementWrap  StencilOperation = 0x00000006
-	StencilOperationDecrementWrap  StencilOperation = 0x00000007
+	StencilOperationUndefined      StencilOperation = 0x00000000
+	StencilOperationKeep           StencilOperation = 0x00000001
+	StencilOperationZero           StencilOperation = 0x00000002
+	StencilOperationReplace        StencilOperation = 0x00000003
+	StencilOperationInvert         StencilOperation = 0x00000004
+	StencilOperationIncrementClamp StencilOperation = 0x00000005
+	StencilOperationDecrementClamp StencilOperation = 0x00000006
+	StencilOperationIncrementWrap  StencilOperation = 0x00000007
+	StencilOperationDecrementWrap  StencilOperation = 0x00000008
 )
 
 func (v StencilOperation) String() string {
 	switch v {
+	case StencilOperationUndefined:
+		return "undefined"
 	case StencilOperationKeep:
 		return "keep"
 	case StencilOperationZero:
@@ -1248,14 +1236,17 @@ func (v StencilOperation) String() string {
 type StorageTextureAccess uint32
 
 const (
-	StorageTextureAccessUndefined StorageTextureAccess = 0x00000000
-	StorageTextureAccessWriteOnly StorageTextureAccess = 0x00000001
-	StorageTextureAccessReadOnly  StorageTextureAccess = 0x00000002
-	StorageTextureAccessReadWrite StorageTextureAccess = 0x00000003
+	StorageTextureAccessBindingNotUsed StorageTextureAccess = 0x00000000
+	StorageTextureAccessUndefined      StorageTextureAccess = 0x00000001
+	StorageTextureAccessWriteOnly      StorageTextureAccess = 0x00000002
+	StorageTextureAccessReadOnly       StorageTextureAccess = 0x00000003
+	StorageTextureAccessReadWrite      StorageTextureAccess = 0x00000004
 )
 
 func (v StorageTextureAccess) String() string {
 	switch v {
+	case StorageTextureAccessBindingNotUsed:
+		return "binding-not-used"
 	case StorageTextureAccessUndefined:
 		return "undefined"
 	case StorageTextureAccessWriteOnly:
@@ -1293,18 +1284,22 @@ func (v StoreOp) String() string {
 type SurfaceGetCurrentTextureStatus uint32
 
 const (
-	SurfaceGetCurrentTextureStatusSuccess     SurfaceGetCurrentTextureStatus = 0x00000000
-	SurfaceGetCurrentTextureStatusTimeout     SurfaceGetCurrentTextureStatus = 0x00000001
-	SurfaceGetCurrentTextureStatusOutdated    SurfaceGetCurrentTextureStatus = 0x00000002
-	SurfaceGetCurrentTextureStatusLost        SurfaceGetCurrentTextureStatus = 0x00000003
-	SurfaceGetCurrentTextureStatusOutOfMemory SurfaceGetCurrentTextureStatus = 0x00000004
-	SurfaceGetCurrentTextureStatusDeviceLost  SurfaceGetCurrentTextureStatus = 0x00000005
+	SurfaceGetCurrentTextureStatusSuccessOptimal    SurfaceGetCurrentTextureStatus = 0x00000001
+	SurfaceGetCurrentTextureStatusSuccessSuboptimal SurfaceGetCurrentTextureStatus = 0x00000002
+	SurfaceGetCurrentTextureStatusTimeout           SurfaceGetCurrentTextureStatus = 0x00000003
+	SurfaceGetCurrentTextureStatusOutdated          SurfaceGetCurrentTextureStatus = 0x00000004
+	SurfaceGetCurrentTextureStatusLost              SurfaceGetCurrentTextureStatus = 0x00000005
+	SurfaceGetCurrentTextureStatusOutOfMemory       SurfaceGetCurrentTextureStatus = 0x00000006
+	SurfaceGetCurrentTextureStatusDeviceLost        SurfaceGetCurrentTextureStatus = 0x00000007
+	SurfaceGetCurrentTextureStatusError             SurfaceGetCurrentTextureStatus = 0x00000008
 )
 
 func (v SurfaceGetCurrentTextureStatus) String() string {
 	switch v {
-	case SurfaceGetCurrentTextureStatusSuccess:
-		return "success"
+	case SurfaceGetCurrentTextureStatusSuccessOptimal:
+		return "success-optimal"
+	case SurfaceGetCurrentTextureStatusSuccessSuboptimal:
+		return "success-suboptimal"
 	case SurfaceGetCurrentTextureStatusTimeout:
 		return "timeout"
 	case SurfaceGetCurrentTextureStatusOutdated:
@@ -1315,6 +1310,8 @@ func (v SurfaceGetCurrentTextureStatus) String() string {
 		return "out-of-memory"
 	case SurfaceGetCurrentTextureStatusDeviceLost:
 		return "device-lost"
+	case SurfaceGetCurrentTextureStatusError:
+		return "error"
 	default:
 		return ""
 	}
@@ -1323,13 +1320,16 @@ func (v SurfaceGetCurrentTextureStatus) String() string {
 type TextureAspect uint32
 
 const (
-	TextureAspectAll         TextureAspect = 0x00000000
-	TextureAspectStencilOnly TextureAspect = 0x00000001
-	TextureAspectDepthOnly   TextureAspect = 0x00000002
+	TextureAspectUndefined   TextureAspect = 0x00000000
+	TextureAspectAll         TextureAspect = 0x00000001
+	TextureAspectStencilOnly TextureAspect = 0x00000002
+	TextureAspectDepthOnly   TextureAspect = 0x00000003
 )
 
 func (v TextureAspect) String() string {
 	switch v {
+	case TextureAspectUndefined:
+		return "undefined"
 	case TextureAspectAll:
 		return "all"
 	case TextureAspectStencilOnly:
@@ -1344,13 +1344,16 @@ func (v TextureAspect) String() string {
 type TextureDimension uint32
 
 const (
-	TextureDimension1D TextureDimension = 0x00000000
-	TextureDimension2D TextureDimension = 0x00000001
-	TextureDimension3D TextureDimension = 0x00000002
+	TextureDimensionUndefined TextureDimension = 0x00000000
+	TextureDimension1D        TextureDimension = 0x00000001
+	TextureDimension2D        TextureDimension = 0x00000002
+	TextureDimension3D        TextureDimension = 0x00000003
 )
 
 func (v TextureDimension) String() string {
 	switch v {
+	case TextureDimensionUndefined:
+		return "undefined"
 	case TextureDimension1D:
 		return "1d"
 	case TextureDimension2D:
@@ -1665,16 +1668,19 @@ func (v TextureFormat) String() string {
 type TextureSampleType uint32
 
 const (
-	TextureSampleTypeUndefined         TextureSampleType = 0x00000000
-	TextureSampleTypeFloat             TextureSampleType = 0x00000001
-	TextureSampleTypeUnfilterableFloat TextureSampleType = 0x00000002
-	TextureSampleTypeDepth             TextureSampleType = 0x00000003
-	TextureSampleTypeSint              TextureSampleType = 0x00000004
-	TextureSampleTypeUint              TextureSampleType = 0x00000005
+	TextureSampleTypeBindingNotUsed    TextureSampleType = 0x00000000
+	TextureSampleTypeUndefined         TextureSampleType = 0x00000001
+	TextureSampleTypeFloat             TextureSampleType = 0x00000002
+	TextureSampleTypeUnfilterableFloat TextureSampleType = 0x00000003
+	TextureSampleTypeDepth             TextureSampleType = 0x00000004
+	TextureSampleTypeSint              TextureSampleType = 0x00000005
+	TextureSampleTypeUint              TextureSampleType = 0x00000006
 )
 
 func (v TextureSampleType) String() string {
 	switch v {
+	case TextureSampleTypeBindingNotUsed:
+		return "binding-not-used"
 	case TextureSampleTypeUndefined:
 		return "undefined"
 	case TextureSampleTypeFloat:
@@ -1687,36 +1693,6 @@ func (v TextureSampleType) String() string {
 		return "sint"
 	case TextureSampleTypeUint:
 		return "uint"
-	default:
-		return ""
-	}
-}
-
-type TextureUsage uint32
-
-const (
-	TextureUsageNone             TextureUsage = 0x00000000
-	TextureUsageCopySrc          TextureUsage = 0x00000001
-	TextureUsageCopyDst          TextureUsage = 0x00000002
-	TextureUsageTextureBinding   TextureUsage = 0x00000004
-	TextureUsageStorageBinding   TextureUsage = 0x00000008
-	TextureUsageRenderAttachment TextureUsage = 0x00000010
-)
-
-func (v TextureUsage) String() string {
-	switch v {
-	case TextureUsageNone:
-		return "none"
-	case TextureUsageCopySrc:
-		return "copy-src"
-	case TextureUsageCopyDst:
-		return "copy-dst"
-	case TextureUsageTextureBinding:
-		return "texture-binding"
-	case TextureUsageStorageBinding:
-		return "storage-binding"
-	case TextureUsageRenderAttachment:
-		return "render-attachment"
 	default:
 		return ""
 	}
@@ -1758,75 +1734,101 @@ func (v TextureViewDimension) String() string {
 type VertexFormat uint32
 
 const (
-	VertexFormatUndefined VertexFormat = 0x00000000
-	VertexFormatUint8x2   VertexFormat = 0x00000001
-	VertexFormatUint8x4   VertexFormat = 0x00000002
-	VertexFormatSint8x2   VertexFormat = 0x00000003
-	VertexFormatSint8x4   VertexFormat = 0x00000004
-	VertexFormatUnorm8x2  VertexFormat = 0x00000005
-	VertexFormatUnorm8x4  VertexFormat = 0x00000006
-	VertexFormatSnorm8x2  VertexFormat = 0x00000007
-	VertexFormatSnorm8x4  VertexFormat = 0x00000008
-	VertexFormatUint16x2  VertexFormat = 0x00000009
-	VertexFormatUint16x4  VertexFormat = 0x0000000A
-	VertexFormatSint16x2  VertexFormat = 0x0000000B
-	VertexFormatSint16x4  VertexFormat = 0x0000000C
-	VertexFormatUnorm16x2 VertexFormat = 0x0000000D
-	VertexFormatUnorm16x4 VertexFormat = 0x0000000E
-	VertexFormatSnorm16x2 VertexFormat = 0x0000000F
-	VertexFormatSnorm16x4 VertexFormat = 0x00000010
-	VertexFormatFloat16x2 VertexFormat = 0x00000011
-	VertexFormatFloat16x4 VertexFormat = 0x00000012
-	VertexFormatFloat32   VertexFormat = 0x00000013
-	VertexFormatFloat32x2 VertexFormat = 0x00000014
-	VertexFormatFloat32x3 VertexFormat = 0x00000015
-	VertexFormatFloat32x4 VertexFormat = 0x00000016
-	VertexFormatUint32    VertexFormat = 0x00000017
-	VertexFormatUint32x2  VertexFormat = 0x00000018
-	VertexFormatUint32x3  VertexFormat = 0x00000019
-	VertexFormatUint32x4  VertexFormat = 0x0000001A
-	VertexFormatSint32    VertexFormat = 0x0000001B
-	VertexFormatSint32x2  VertexFormat = 0x0000001C
-	VertexFormatSint32x3  VertexFormat = 0x0000001D
-	VertexFormatSint32x4  VertexFormat = 0x0000001E
+	VertexFormatUint8        VertexFormat = 0x00000001
+	VertexFormatUint8x2      VertexFormat = 0x00000002
+	VertexFormatUint8x4      VertexFormat = 0x00000003
+	VertexFormatSint8        VertexFormat = 0x00000004
+	VertexFormatSint8x2      VertexFormat = 0x00000005
+	VertexFormatSint8x4      VertexFormat = 0x00000006
+	VertexFormatUnorm8       VertexFormat = 0x00000007
+	VertexFormatUnorm8x2     VertexFormat = 0x00000008
+	VertexFormatUnorm8x4     VertexFormat = 0x00000009
+	VertexFormatSnorm8       VertexFormat = 0x0000000A
+	VertexFormatSnorm8x2     VertexFormat = 0x0000000B
+	VertexFormatSnorm8x4     VertexFormat = 0x0000000C
+	VertexFormatUint16       VertexFormat = 0x0000000D
+	VertexFormatUint16x2     VertexFormat = 0x0000000E
+	VertexFormatUint16x4     VertexFormat = 0x0000000F
+	VertexFormatSint16       VertexFormat = 0x00000010
+	VertexFormatSint16x2     VertexFormat = 0x00000011
+	VertexFormatSint16x4     VertexFormat = 0x00000012
+	VertexFormatUnorm16      VertexFormat = 0x00000013
+	VertexFormatUnorm16x2    VertexFormat = 0x00000014
+	VertexFormatUnorm16x4    VertexFormat = 0x00000015
+	VertexFormatSnorm16      VertexFormat = 0x00000016
+	VertexFormatSnorm16x2    VertexFormat = 0x00000017
+	VertexFormatSnorm16x4    VertexFormat = 0x00000018
+	VertexFormatFloat16      VertexFormat = 0x00000019
+	VertexFormatFloat16x2    VertexFormat = 0x0000001A
+	VertexFormatFloat16x4    VertexFormat = 0x0000001B
+	VertexFormatFloat32      VertexFormat = 0x0000001C
+	VertexFormatFloat32x2    VertexFormat = 0x0000001D
+	VertexFormatFloat32x3    VertexFormat = 0x0000001E
+	VertexFormatFloat32x4    VertexFormat = 0x0000001F
+	VertexFormatUint32       VertexFormat = 0x00000020
+	VertexFormatUint32x2     VertexFormat = 0x00000021
+	VertexFormatUint32x3     VertexFormat = 0x00000022
+	VertexFormatUint32x4     VertexFormat = 0x00000023
+	VertexFormatSint32       VertexFormat = 0x00000024
+	VertexFormatSint32x2     VertexFormat = 0x00000025
+	VertexFormatSint32x3     VertexFormat = 0x00000026
+	VertexFormatSint32x4     VertexFormat = 0x00000027
+	VertexFormatUnorm1010102 VertexFormat = 0x00000028
+	VertexFormatUnorm8x4BGRA VertexFormat = 0x00000029
 )
 
 func (v VertexFormat) String() string {
 	switch v {
-	case VertexFormatUndefined:
-		return "undefined"
+	case VertexFormatUint8:
+		return "uint8"
 	case VertexFormatUint8x2:
 		return "uint8x2"
 	case VertexFormatUint8x4:
 		return "uint8x4"
+	case VertexFormatSint8:
+		return "sint8"
 	case VertexFormatSint8x2:
 		return "sint8x2"
 	case VertexFormatSint8x4:
 		return "sint8x4"
+	case VertexFormatUnorm8:
+		return "unorm8"
 	case VertexFormatUnorm8x2:
 		return "unorm8x2"
 	case VertexFormatUnorm8x4:
 		return "unorm8x4"
+	case VertexFormatSnorm8:
+		return "snorm8"
 	case VertexFormatSnorm8x2:
 		return "snorm8x2"
 	case VertexFormatSnorm8x4:
 		return "snorm8x4"
+	case VertexFormatUint16:
+		return "uint16"
 	case VertexFormatUint16x2:
 		return "uint16x2"
 	case VertexFormatUint16x4:
 		return "uint16x4"
+	case VertexFormatSint16:
+		return "sint16"
 	case VertexFormatSint16x2:
 		return "sint16x2"
 	case VertexFormatSint16x4:
 		return "sint16x4"
+	case VertexFormatUnorm16:
+		return "unorm16"
 	case VertexFormatUnorm16x2:
 		return "unorm16x2"
 	case VertexFormatUnorm16x4:
 		return "unorm16x4"
+	case VertexFormatSnorm16:
+		return "snorm16"
 	case VertexFormatSnorm16x2:
 		return "snorm16x2"
 	case VertexFormatSnorm16x4:
 		return "snorm16x4"
+	case VertexFormatFloat16:
+		return "float16"
 	case VertexFormatFloat16x2:
 		return "float16x2"
 	case VertexFormatFloat16x4:
@@ -1855,6 +1857,10 @@ func (v VertexFormat) String() string {
 		return "sint32x3"
 	case VertexFormatSint32x4:
 		return "sint32x4"
+	case VertexFormatUnorm1010102:
+		return "unorm1010102"
+	case VertexFormatUnorm8x4BGRA:
+		return "unorm8x4bgra"
 	default:
 		return ""
 	}
@@ -1863,47 +1869,147 @@ func (v VertexFormat) String() string {
 type VertexStepMode uint32
 
 const (
-	VertexStepModeVertex              VertexStepMode = 0x00000000
-	VertexStepModeInstance            VertexStepMode = 0x00000001
-	VertexStepModeVertexBufferNotUsed VertexStepMode = 0x00000002
+	VertexStepModeVertexBufferNotUsed VertexStepMode = 0x00000000
+	VertexStepModeUndefined           VertexStepMode = 0x00000001
+	VertexStepModeVertex              VertexStepMode = 0x00000002
+	VertexStepModeInstance            VertexStepMode = 0x00000003
 )
 
 func (v VertexStepMode) String() string {
 	switch v {
+	case VertexStepModeVertexBufferNotUsed:
+		return "vertex-buffer-not-used"
+	case VertexStepModeUndefined:
+		return "undefined"
 	case VertexStepModeVertex:
 		return "vertex"
 	case VertexStepModeInstance:
 		return "instance"
-	case VertexStepModeVertexBufferNotUsed:
-		return "vertex-buffer-not-used"
 	default:
 		return ""
 	}
 }
 
-type WGSLFeatureName uint32
+type WGSLLanguageFeatureName uint32
 
 const (
-	WGSLFeatureNameUndefined                           WGSLFeatureName = 0x00000000
-	WGSLFeatureNameReadonlyAndReadwriteStorageTextures WGSLFeatureName = 0x00000001
-	WGSLFeatureNamePacked4x8IntegerDotProduct          WGSLFeatureName = 0x00000002
-	WGSLFeatureNameUnrestrictedPointerParameters       WGSLFeatureName = 0x00000003
-	WGSLFeatureNamePointerCompositeAccess              WGSLFeatureName = 0x00000004
+	WGSLLanguageFeatureNameReadonlyAndReadwriteStorageTextures WGSLLanguageFeatureName = 0x00000001
+	WGSLLanguageFeatureNamePacked4x8IntegerDotProduct          WGSLLanguageFeatureName = 0x00000002
+	WGSLLanguageFeatureNameUnrestrictedPointerParameters       WGSLLanguageFeatureName = 0x00000003
+	WGSLLanguageFeatureNamePointerCompositeAccess              WGSLLanguageFeatureName = 0x00000004
 )
 
-func (v WGSLFeatureName) String() string {
+func (v WGSLLanguageFeatureName) String() string {
 	switch v {
-	case WGSLFeatureNameUndefined:
-		return "undefined"
-	case WGSLFeatureNameReadonlyAndReadwriteStorageTextures:
+	case WGSLLanguageFeatureNameReadonlyAndReadwriteStorageTextures:
 		return "readonly-and-readwrite-storage-textures"
-	case WGSLFeatureNamePacked4x8IntegerDotProduct:
+	case WGSLLanguageFeatureNamePacked4x8IntegerDotProduct:
 		return "packed4x8integer-dot-product"
-	case WGSLFeatureNameUnrestrictedPointerParameters:
+	case WGSLLanguageFeatureNameUnrestrictedPointerParameters:
 		return "unrestricted-pointer-parameters"
-	case WGSLFeatureNamePointerCompositeAccess:
+	case WGSLLanguageFeatureNamePointerCompositeAccess:
 		return "pointer-composite-access"
 	default:
 		return ""
 	}
 }
+
+type WaitStatus uint32
+
+const (
+	WaitStatusSuccess                 WaitStatus = 0x00000001
+	WaitStatusTimedOut                WaitStatus = 0x00000002
+	WaitStatusUnsupportedTimeout      WaitStatus = 0x00000003
+	WaitStatusUnsupportedCount        WaitStatus = 0x00000004
+	WaitStatusUnsupportedMixedSources WaitStatus = 0x00000005
+)
+
+func (v WaitStatus) String() string {
+	switch v {
+	case WaitStatusSuccess:
+		return "success"
+	case WaitStatusTimedOut:
+		return "timed-out"
+	case WaitStatusUnsupportedTimeout:
+		return "unsupported-timeout"
+	case WaitStatusUnsupportedCount:
+		return "unsupported-count"
+	case WaitStatusUnsupportedMixedSources:
+		return "unsupported-mixed-sources"
+	default:
+		return ""
+	}
+}
+
+type BufferUsage uint64
+const (
+	BufferUsageNone         BufferUsage = 0x0000000000000000
+	BufferUsageMapRead      BufferUsage = 0x0000000000000001
+	BufferUsageMapWrite     BufferUsage = 0x0000000000000002
+	BufferUsageCopySrc      BufferUsage = 0x0000000000000004
+	BufferUsageCopyDst      BufferUsage = 0x0000000000000008
+	BufferUsageIndex        BufferUsage = 0x0000000000000010
+	BufferUsageVertex       BufferUsage = 0x0000000000000020
+	BufferUsageUniform      BufferUsage = 0x0000000000000040
+	BufferUsageStorage      BufferUsage = 0x0000000000000080
+	BufferUsageIndirect     BufferUsage = 0x0000000000000100
+	BufferUsageQueryResolve BufferUsage = 0x0000000000000200
+)
+
+type ColorWriteMask uint64
+const (
+	ColorWriteMaskNone  ColorWriteMask = 0x0000000000000000
+	ColorWriteMaskRed   ColorWriteMask = 0x0000000000000001
+	ColorWriteMaskGreen ColorWriteMask = 0x0000000000000002
+	ColorWriteMaskBlue  ColorWriteMask = 0x0000000000000004
+	ColorWriteMaskAlpha ColorWriteMask = 0x0000000000000008
+	ColorWriteMaskAll   ColorWriteMask = 0x000000000000000F /* Red | Green | Blue | Alpha */
+)
+
+type MapMode uint64
+const (
+	MapModeNone  MapMode = 0x0000000000000000
+	MapModeRead  MapMode = 0x0000000000000001
+	MapModeWrite MapMode = 0x0000000000000002
+)
+
+type ShaderStage uint64
+const (
+	ShaderStageNone     ShaderStage = 0x0000000000000000
+	ShaderStageVertex   ShaderStage = 0x0000000000000001
+	ShaderStageFragment ShaderStage = 0x0000000000000002
+	ShaderStageCompute  ShaderStage = 0x0000000000000004
+)
+
+type TextureUsage uint64
+const (
+	TextureUsageNone            TextureUsage = 0x0000000000000000
+	TextureUsageCopySrc         TextureUsage = 0x0000000000000001
+	TextureUsageCopyDst         TextureUsage = 0x0000000000000002
+	TextureUsageTextureBinding  TextureUsage = 0x0000000000000004
+	TextureUsageStorageBinding  TextureUsage = 0x0000000000000008
+	TextureUsageRenderAttachment TextureUsage = 0x0000000000000010
+)
+
+type InstanceBackend uint32
+const (
+	WGPUInstanceBackend_All InstanceBackend = 0x00000000
+	WGPUInstanceBackend_Vulkan InstanceBackend = 1 << 0
+	WGPUInstanceBackend_GL InstanceBackend = 1 << 1
+	WGPUInstanceBackend_Metal InstanceBackend = 1 << 2
+	WGPUInstanceBackend_DX12 InstanceBackend = 1 << 3
+	WGPUInstanceBackend_DX11 InstanceBackend = 1 << 4
+	WGPUInstanceBackend_BrowserWebGPU InstanceBackend = 1 << 5
+	WGPUInstanceBackend_Primary InstanceBackend = (1 << 0) | (1 << 2) | (1 << 3) | (1 << 5)
+	WGPUInstanceBackend_Secondary InstanceBackend = (1 << 1) | (1 << 4)
+	WGPUInstanceBackend_Force32 InstanceBackend = 0x7FFFFFFF
+)
+
+type InstanceFlag uint32
+const (
+	WGPUInstanceFlag_Default InstanceFlag = 0x00000000
+	WGPUInstanceFlag_Debug InstanceFlag = 1 << 0
+	WGPUInstanceFlag_Validation InstanceFlag = 1 << 1
+	WGPUInstanceFlag_DiscardHalLabels InstanceFlag = 1 << 2
+	WGPUInstanceFlag_Force32 InstanceFlag = 0x7FFFFFFF
+)

--- a/wgpu/enums.go
+++ b/wgpu/enums.go
@@ -188,39 +188,39 @@ func (v BufferBindingType) String() string {
 	}
 }
 
-type BufferMapAsyncStatus uint32
+type MapAsyncStatus uint32
 
 const (
-	BufferMapAsyncStatusSuccess                 BufferMapAsyncStatus = 0x00000000
-	BufferMapAsyncStatusValidationError         BufferMapAsyncStatus = 0x00000001
-	BufferMapAsyncStatusUnknown                 BufferMapAsyncStatus = 0x00000002
-	BufferMapAsyncStatusDeviceLost              BufferMapAsyncStatus = 0x00000003
-	BufferMapAsyncStatusDestroyedBeforeCallback BufferMapAsyncStatus = 0x00000004
-	BufferMapAsyncStatusUnmappedBeforeCallback  BufferMapAsyncStatus = 0x00000005
-	BufferMapAsyncStatusMappingAlreadyPending   BufferMapAsyncStatus = 0x00000006
-	BufferMapAsyncStatusOffsetOutOfRange        BufferMapAsyncStatus = 0x00000007
-	BufferMapAsyncStatusSizeOutOfRange          BufferMapAsyncStatus = 0x00000008
+	MapAsyncStatusSuccess                 MapAsyncStatus = 0x00000000
+	MapAsyncStatusValidationError         MapAsyncStatus = 0x00000001
+	MapAsyncStatusUnknown                 MapAsyncStatus = 0x00000002
+	MapAsyncStatusDeviceLost              MapAsyncStatus = 0x00000003
+	MapAsyncStatusDestroyedBeforeCallback MapAsyncStatus = 0x00000004
+	MapAsyncStatusUnmappedBeforeCallback  MapAsyncStatus = 0x00000005
+	MapAsyncStatusMappingAlreadyPending   MapAsyncStatus = 0x00000006
+	MapAsyncStatusOffsetOutOfRange        MapAsyncStatus = 0x00000007
+	MapAsyncStatusSizeOutOfRange          MapAsyncStatus = 0x00000008
 )
 
-func (v BufferMapAsyncStatus) String() string {
+func (v MapAsyncStatus) String() string {
 	switch v {
-	case BufferMapAsyncStatusSuccess:
+	case MapAsyncStatusSuccess:
 		return "success"
-	case BufferMapAsyncStatusValidationError:
+	case MapAsyncStatusValidationError:
 		return "validation-error"
-	case BufferMapAsyncStatusUnknown:
+	case MapAsyncStatusUnknown:
 		return "unknown"
-	case BufferMapAsyncStatusDeviceLost:
+	case MapAsyncStatusDeviceLost:
 		return "device-lost"
-	case BufferMapAsyncStatusDestroyedBeforeCallback:
+	case MapAsyncStatusDestroyedBeforeCallback:
 		return "destroyed-before-callback"
-	case BufferMapAsyncStatusUnmappedBeforeCallback:
+	case MapAsyncStatusUnmappedBeforeCallback:
 		return "unmapped-before-callback"
-	case BufferMapAsyncStatusMappingAlreadyPending:
+	case MapAsyncStatusMappingAlreadyPending:
 		return "mapping-already-pending"
-	case BufferMapAsyncStatusOffsetOutOfRange:
+	case MapAsyncStatusOffsetOutOfRange:
 		return "offset-out-of-range"
-	case BufferMapAsyncStatusSizeOutOfRange:
+	case MapAsyncStatusSizeOutOfRange:
 		return "size-out-of-range"
 	default:
 		return ""

--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -33,14 +33,6 @@ func CreateInstance(descriptor *InstanceDescriptor) *Instance {
 		instanceExtras.backends = C.WGPUInstanceBackend(descriptor.Backends)
 		instanceExtras.dx12ShaderCompiler = C.WGPUDx12Compiler(descriptor.Dx12ShaderCompiler)
 
-		if descriptor.DxilPath != "" {
-			dxilPath := C.CString(descriptor.DxilPath)
-			defer C.free(unsafe.Pointer(dxilPath))
-
-			instanceExtras.dxilPath.data = dxilPath
-			instanceExtras.dxilPath.length = C.WGPU_STRLEN
-		}
-
 		if descriptor.DxcPath != "" {
 			dxcPath := C.CString(descriptor.DxcPath)
 			defer C.free(unsafe.Pointer(dxcPath))

--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -192,13 +192,13 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 type requestAdapterCb func(status RequestAdapterStatus, adapter *Adapter, message string)
 
 //export gowebgpu_request_adapter_callback_go
-func gowebgpu_request_adapter_callback_go(status C.WGPURequestAdapterStatus, adapter C.WGPUAdapter, message *C.char, userdata unsafe.Pointer) {
+func gowebgpu_request_adapter_callback_go(status C.WGPURequestAdapterStatus, adapter C.WGPUAdapter, message C.WGPUStringView, userdata unsafe.Pointer) {
 	handle := *(*cgo.Handle)(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(requestAdapterCb)
 	if ok {
-		cb(RequestAdapterStatus(status), &Adapter{ref: adapter}, C.GoString(message))
+		cb(RequestAdapterStatus(status), &Adapter{ref: adapter}, C.GoStringN(message.data, C.int(message.length)))
 	}
 }
 

--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAdapter adapter, char const *message, void *userdata);
 

--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -30,7 +30,7 @@ func CreateInstance(descriptor *InstanceDescriptor) *Instance {
 
 		instanceExtras.chain.next = nil
 		instanceExtras.chain.sType = C.WGPUSType_InstanceExtras
-		instanceExtras.backends = C.WGPUInstanceBackendFlags(descriptor.Backends)
+		instanceExtras.backends = C.WGPUInstanceBackend(descriptor.Backends)
 		instanceExtras.dx12ShaderCompiler = C.WGPUDx12Compiler(descriptor.Dx12ShaderCompiler)
 
 		if descriptor.DxilPath != "" {
@@ -56,43 +56,43 @@ func CreateInstance(descriptor *InstanceDescriptor) *Instance {
 	return &Instance{ref}
 }
 
-type SurfaceDescriptorFromWindowsHWND struct {
+type SurfaceSourceWindowsHWND struct {
 	Hinstance unsafe.Pointer
 	Hwnd      unsafe.Pointer
 }
 
-type SurfaceDescriptorFromXcbWindow struct {
+type SurfaceSourceXcbWindow struct {
 	Connection unsafe.Pointer
 	Window     uint32
 }
 
-type SurfaceDescriptorFromXlibWindow struct {
+type SurfaceSourceXlibWindow struct {
 	Display unsafe.Pointer
 	Window  uint32
 }
 
-type SurfaceDescriptorFromMetalLayer struct {
+type SurfaceSourceMetalLayer struct {
 	Layer unsafe.Pointer
 }
 
-type SurfaceDescriptorFromWaylandSurface struct {
+type SurfaceSourceWaylandSurface struct {
 	Display unsafe.Pointer
 	Surface unsafe.Pointer
 }
 
-type SurfaceDescriptorFromAndroidNativeWindow struct {
+type SurfaceSourceAndroidNativeWindow struct {
 	Window unsafe.Pointer
 }
 
 type SurfaceDescriptor struct {
 	Label string
 
-	WindowsHWND         *SurfaceDescriptorFromWindowsHWND
-	XcbWindow           *SurfaceDescriptorFromXcbWindow
-	XlibWindow          *SurfaceDescriptorFromXlibWindow
-	MetalLayer          *SurfaceDescriptorFromMetalLayer
-	WaylandSurface      *SurfaceDescriptorFromWaylandSurface
-	AndroidNativeWindow *SurfaceDescriptorFromAndroidNativeWindow
+	WindowsHWND         *SurfaceSourceWindowsHWND
+	XcbWindow           *SurfaceSourceXcbWindow
+	XlibWindow          *SurfaceSourceXlibWindow
+	MetalLayer          *SurfaceSourceMetalLayer
+	WaylandSurface      *SurfaceSourceWaylandSurface
+	AndroidNativeWindow *SurfaceSourceAndroidNativeWindow
 }
 
 func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
@@ -107,11 +107,11 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 		}
 
 		if descriptor.WindowsHWND != nil {
-			windowsHWND := (*C.WGPUSurfaceDescriptorFromWindowsHWND)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromWindowsHWND{}))))
+			windowsHWND := (*C.WGPUSurfaceSourceWindowsHWND)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceWindowsHWND{}))))
 			defer C.free(unsafe.Pointer(windowsHWND))
 
 			windowsHWND.chain.next = nil
-			windowsHWND.chain.sType = C.WGPUSType_SurfaceDescriptorFromWindowsHWND
+			windowsHWND.chain.sType = C.WGPUSType_SurfaceSourceWindowsHWND
 			windowsHWND.hinstance = descriptor.WindowsHWND.Hinstance
 			windowsHWND.hwnd = descriptor.WindowsHWND.Hwnd
 
@@ -119,11 +119,11 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 		}
 
 		if descriptor.XcbWindow != nil {
-			xcbWindow := (*C.WGPUSurfaceDescriptorFromXcbWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromXcbWindow{}))))
+			xcbWindow := (*C.WGPUSurfaceSourceXCBWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceXCBWindow{}))))
 			defer C.free(unsafe.Pointer(xcbWindow))
 
 			xcbWindow.chain.next = nil
-			xcbWindow.chain.sType = C.WGPUSType_SurfaceDescriptorFromXcbWindow
+			xcbWindow.chain.sType = C.WGPUSType_SurfaceSourceXCBWindow
 			xcbWindow.connection = descriptor.XcbWindow.Connection
 			xcbWindow.window = C.uint32_t(descriptor.XcbWindow.Window)
 
@@ -131,11 +131,11 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 		}
 
 		if descriptor.XlibWindow != nil {
-			xlibWindow := (*C.WGPUSurfaceDescriptorFromXlibWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromXlibWindow{}))))
+			xlibWindow := (*C.WGPUSurfaceSourceXlibWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceXlibWindow{}))))
 			defer C.free(unsafe.Pointer(xlibWindow))
 
 			xlibWindow.chain.next = nil
-			xlibWindow.chain.sType = C.WGPUSType_SurfaceDescriptorFromXlibWindow
+			xlibWindow.chain.sType = C.WGPUSType_SurfaceSourceXlibWindow
 			xlibWindow.display = descriptor.XlibWindow.Display
 			xlibWindow.window = C.uint64_t(descriptor.XlibWindow.Window)
 
@@ -143,22 +143,22 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 		}
 
 		if descriptor.MetalLayer != nil {
-			metalLayer := (*C.WGPUSurfaceDescriptorFromMetalLayer)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromMetalLayer{}))))
+			metalLayer := (*C.WGPUSurfaceSourceMetalLayer)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceMetalLayer{}))))
 			defer C.free(unsafe.Pointer(metalLayer))
 
 			metalLayer.chain.next = nil
-			metalLayer.chain.sType = C.WGPUSType_SurfaceDescriptorFromMetalLayer
+			metalLayer.chain.sType = C.WGPUSType_SurfaceSourceMetalLayer
 			metalLayer.layer = descriptor.MetalLayer.Layer
 
 			desc.nextInChain = (*C.WGPUChainedStruct)(unsafe.Pointer(metalLayer))
 		}
 
 		if descriptor.WaylandSurface != nil {
-			waylandSurface := (*C.WGPUSurfaceDescriptorFromWaylandSurface)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromWaylandSurface{}))))
+			waylandSurface := (*C.WGPUSurfaceSourceWaylandSurface)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceWaylandSurface{}))))
 			defer C.free(unsafe.Pointer(waylandSurface))
 
 			waylandSurface.chain.next = nil
-			waylandSurface.chain.sType = C.WGPUSType_SurfaceDescriptorFromWaylandSurface
+			waylandSurface.chain.sType = C.WGPUSType_SurfaceSourceWaylandSurface
 			waylandSurface.display = descriptor.WaylandSurface.Display
 			waylandSurface.surface = descriptor.WaylandSurface.Surface
 
@@ -166,11 +166,11 @@ func (p *Instance) CreateSurface(descriptor *SurfaceDescriptor) *Surface {
 		}
 
 		if descriptor.AndroidNativeWindow != nil {
-			androidNativeWindow := (*C.WGPUSurfaceDescriptorFromAndroidNativeWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceDescriptorFromAndroidNativeWindow{}))))
+			androidNativeWindow := (*C.WGPUSurfaceSourceAndroidNativeWindow)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUSurfaceSourceAndroidNativeWindow{}))))
 			defer C.free(unsafe.Pointer(androidNativeWindow))
 
 			androidNativeWindow.chain.next = nil
-			androidNativeWindow.chain.sType = C.WGPUSType_SurfaceDescriptorFromAndroidNativeWindow
+			androidNativeWindow.chain.sType = C.WGPUSType_SurfaceSourceAndroidNativeWindow
 			androidNativeWindow.window = descriptor.AndroidNativeWindow.Window
 
 			desc.nextInChain = (*C.WGPUChainedStruct)(unsafe.Pointer(androidNativeWindow))
@@ -219,7 +219,10 @@ func (p *Instance) RequestAdapter(options *RequestAdapterOptions) (*Adapter, err
 		adapter = a
 	}
 	handle := cgo.NewHandle(cb)
-	C.wgpuInstanceRequestAdapter(p.ref, opts, C.WGPUInstanceRequestAdapterCallback(C.gowebgpu_request_adapter_callback_c), unsafe.Pointer(&handle))
+	C.wgpuInstanceRequestAdapter(p.ref, opts, C.WGPURequestAdapterCallbackInfo{
+		callback:  C.gowebgpu_request_adapter_callback_c,
+		userdata1: unsafe.Pointer(&handle),
+	})
 
 	if status != RequestAdapterStatusSuccess {
 		return nil, errors.New("failed to request adapter")
@@ -231,7 +234,7 @@ func (p *Instance) EnumerateAdapters(options *InstanceEnumerateAdapterOptons) []
 	var opts *C.WGPUInstanceEnumerateAdapterOptions
 	if options != nil {
 		opts = &C.WGPUInstanceEnumerateAdapterOptions{
-			backends: C.WGPUInstanceBackendFlags(options.Backends),
+			backends: C.WGPUInstanceBackend(options.Backends),
 		}
 	}
 

--- a/wgpu/lib/vendor.go
+++ b/wgpu/lib/vendor.go
@@ -13,5 +13,8 @@ import (
 	_ "github.com/cogentcore/webgpu/wgpu/lib/ios/amd64"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/ios/arm64"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/linux/amd64"
+	_ "github.com/cogentcore/webgpu/wgpu/lib/linux/arm64"
+	_ "github.com/cogentcore/webgpu/wgpu/lib/windows/386"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/windows/amd64"
+	_ "github.com/cogentcore/webgpu/wgpu/lib/windows/arm64"
 )

--- a/wgpu/lib/wgpu.h
+++ b/wgpu/lib/wgpu.h
@@ -8,7 +8,7 @@ typedef enum WGPUNativeSType {
     WGPUSType_DeviceExtras = 0x00030001,
     WGPUSType_NativeLimits = 0x00030002,
     WGPUSType_PipelineLayoutExtras = 0x00030003,
-    WGPUSType_ShaderModuleGLSLDescriptor = 0x00030004,
+    WGPUSType_ShaderSourceGLSL = 0x00030004,
     WGPUSType_InstanceExtras = 0x00030006,
     WGPUSType_BindGroupEntryExtras = 0x00030007,
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
@@ -159,19 +159,13 @@ typedef struct WGPUShaderDefine {
     WGPUStringView value;
 } WGPUShaderDefine;
 
-typedef struct WGPUShaderModuleGLSLDescriptor {
+typedef struct WGPUShaderSourceGLSL {
     WGPUChainedStruct chain;
     WGPUShaderStage stage;
     WGPUStringView code;
     uint32_t defineCount;
     WGPUShaderDefine * defines;
-} WGPUShaderModuleGLSLDescriptor;
-
-typedef struct WGPUShaderModuleDescriptorSpirV {
-    WGPUStringView label;
-    uint32_t sourceSize;
-    uint32_t const * source;
-} WGPUShaderModuleDescriptorSpirV;
+} WGPUShaderSourceGLSL;
 
 typedef struct WGPURegistryReport {
    size_t numAllocated;
@@ -261,7 +255,6 @@ WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
 WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * wrappedSubmissionIndex);
-WGPUShaderModule wgpuDeviceCreateShaderModuleSpirV(WGPUDevice device, WGPUShaderModuleDescriptorSpirV const * descriptor);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 

--- a/wgpu/lib/wgpu.h
+++ b/wgpu/lib/wgpu.h
@@ -254,7 +254,7 @@ size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPU_NULLABLE WGPUIn
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
-WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * wrappedSubmissionIndex);
+WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * submissionIndex);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 

--- a/wgpu/lib/wgpu.h
+++ b/wgpu/lib/wgpu.h
@@ -6,10 +6,9 @@
 typedef enum WGPUNativeSType {
     // Start at 0003 since that's allocated range for wgpu-native
     WGPUSType_DeviceExtras = 0x00030001,
-    WGPUSType_RequiredLimitsExtras = 0x00030002,
+    WGPUSType_NativeLimits = 0x00030002,
     WGPUSType_PipelineLayoutExtras = 0x00030003,
     WGPUSType_ShaderModuleGLSLDescriptor = 0x00030004,
-    WGPUSType_SupportedLimitsExtras = 0x00030005,
     WGPUSType_InstanceExtras = 0x00030006,
     WGPUSType_BindGroupEntryExtras = 0x00030007,
     WGPUSType_BindGroupLayoutEntryExtras = 0x00030008,
@@ -31,8 +30,6 @@ typedef enum WGPUNativeFeature {
     WGPUNativeFeature_PartiallyBoundBindingArray = 0x0003000A,
     WGPUNativeFeature_TextureFormat16bitNorm = 0x0003000B,
     WGPUNativeFeature_TextureCompressionAstcHdr = 0x0003000C,
-    // TODO: requires wgpu.h api change
-    // WGPUNativeFeature_TimestampQueryInsidePasses = 0x0003000D,
     WGPUNativeFeature_MappablePrimaryBuffers = 0x0003000E,
     WGPUNativeFeature_BufferBindingArray = 0x0003000F,
     WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing = 0x00030010,
@@ -43,17 +40,21 @@ typedef enum WGPUNativeFeature {
     // WGPUNativeFeature_PolygonModePoint = 0x00030014,
     // WGPUNativeFeature_ConservativeRasterization = 0x00030015,
     // WGPUNativeFeature_ClearTexture = 0x00030016,
-    // WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
+    WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
     // WGPUNativeFeature_Multiview = 0x00030018,
     WGPUNativeFeature_VertexAttribute64bit = 0x00030019,
-    WGPUNativeFeature_ShaderUnusedVertexOutput = 0x0003001A,
-    WGPUNativeFeature_TextureFormatNv12 = 0x0003001B,
-    WGPUNativeFeature_RayTracingAccelerationStructure = 0x0003001C,
-    WGPUNativeFeature_RayQuery = 0x0003001D,
-    WGPUNativeFeature_ShaderF64 = 0x0003001E,
-    WGPUNativeFeature_ShaderI16 = 0x0003001F,
-    WGPUNativeFeature_ShaderPrimitiveIndex = 0x00030020,
-    WGPUNativeFeature_ShaderEarlyDepthTest = 0x00030021,
+    WGPUNativeFeature_TextureFormatNv12 = 0x0003001A,
+    WGPUNativeFeature_RayTracingAccelerationStructure = 0x0003001B,
+    WGPUNativeFeature_RayQuery = 0x0003001C,
+    WGPUNativeFeature_ShaderF64 = 0x0003001D,
+    WGPUNativeFeature_ShaderI16 = 0x0003001E,
+    WGPUNativeFeature_ShaderPrimitiveIndex = 0x0003001F,
+    WGPUNativeFeature_ShaderEarlyDepthTest = 0x00030020,
+    WGPUNativeFeature_Subgroup = 0x00030021,
+    WGPUNativeFeature_SubgroupVertex = 0x00030022,
+    WGPUNativeFeature_SubgroupBarrier = 0x00030023,
+    WGPUNativeFeature_TimestampQueryInsideEncoders = 0x00030024,
+    WGPUNativeFeature_TimestampQueryInsidePasses = 0x00030025,
     WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
@@ -67,30 +68,26 @@ typedef enum WGPULogLevel {
     WGPULogLevel_Force32 = 0x7FFFFFFF
 } WGPULogLevel;
 
-typedef enum WGPUInstanceBackend {
-    WGPUInstanceBackend_All = 0x00000000,
-    WGPUInstanceBackend_Vulkan = 1 << 0,
-    WGPUInstanceBackend_GL = 1 << 1,
-    WGPUInstanceBackend_Metal = 1 << 2,
-    WGPUInstanceBackend_DX12 = 1 << 3,
-    WGPUInstanceBackend_DX11 = 1 << 4,
-    WGPUInstanceBackend_BrowserWebGPU = 1 << 5,
-    WGPUInstanceBackend_Primary = WGPUInstanceBackend_Vulkan | WGPUInstanceBackend_Metal |
-        WGPUInstanceBackend_DX12 |
-        WGPUInstanceBackend_BrowserWebGPU,
-    WGPUInstanceBackend_Secondary = WGPUInstanceBackend_GL | WGPUInstanceBackend_DX11,
-    WGPUInstanceBackend_Force32 = 0x7FFFFFFF
-} WGPUInstanceBackend;
-typedef WGPUFlags WGPUInstanceBackendFlags;
+typedef WGPUFlags WGPUInstanceBackend;
+static const WGPUInstanceBackend WGPUInstanceBackend_All = 0x00000000;
+static const WGPUInstanceBackend WGPUInstanceBackend_Vulkan = 1 << 0;
+static const WGPUInstanceBackend WGPUInstanceBackend_GL = 1 << 1;
+static const WGPUInstanceBackend WGPUInstanceBackend_Metal = 1 << 2;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX12 = 1 << 3;
+static const WGPUInstanceBackend WGPUInstanceBackend_DX11 = 1 << 4;
+static const WGPUInstanceBackend WGPUInstanceBackend_BrowserWebGPU = 1 << 5;
+// Vulkan, Metal, DX12 and BrowserWebGPU
+static const WGPUInstanceBackend WGPUInstanceBackend_Primary = (1 << 0) | (1 << 2) | (1 << 3) | (1 << 5);
+// GL and DX11
+static const WGPUInstanceBackend WGPUInstanceBackend_Secondary = (1 << 1) | (1 << 4);
+static const WGPUInstanceBackend WGPUInstanceBackend_Force32 = 0x7FFFFFFF;
 
-typedef enum WGPUInstanceFlag {
-    WGPUInstanceFlag_Default = 0x00000000,
-    WGPUInstanceFlag_Debug = 1 << 0,
-    WGPUInstanceFlag_Validation = 1 << 1,
-    WGPUInstanceFlag_DiscardHalLabels = 1 << 2,
-    WGPUInstanceFlag_Force32 = 0x7FFFFFFF
-} WGPUInstanceFlag;
-typedef WGPUFlags WGPUInstanceFlags;
+typedef WGPUFlags WGPUInstanceFlag;
+static const WGPUInstanceFlag WGPUInstanceFlag_Default = 0x00000000;
+static const WGPUInstanceFlag WGPUInstanceFlag_Debug = 1 << 0;
+static const WGPUInstanceFlag WGPUInstanceFlag_Validation = 1 << 1;
+static const WGPUInstanceFlag WGPUInstanceFlag_DiscardHalLabels = 1 << 2;
+static const WGPUInstanceFlag WGPUInstanceFlag_Force32 = 0x7FFFFFFF;
 
 typedef enum WGPUDx12Compiler {
     WGPUDx12Compiler_Undefined = 0x00000000,
@@ -123,36 +120,28 @@ typedef enum WGPUNativeQueryType {
 
 typedef struct WGPUInstanceExtras {
     WGPUChainedStruct chain;
-    WGPUInstanceBackendFlags backends;
-    WGPUInstanceFlags flags;
+    WGPUInstanceBackend backends;
+    WGPUInstanceFlag flags;
     WGPUDx12Compiler dx12ShaderCompiler;
     WGPUGles3MinorVersion gles3MinorVersion;
-    const char * dxilPath;
-    const char * dxcPath;
+    WGPUStringView dxilPath;
+    WGPUStringView dxcPath;
 } WGPUInstanceExtras;
 
 typedef struct WGPUDeviceExtras {
     WGPUChainedStruct chain;
-    const char * tracePath;
+    WGPUStringView tracePath;
 } WGPUDeviceExtras;
 
 typedef struct WGPUNativeLimits {
+    /** This struct chain is used as mutable in some places and immutable in others. */
+    WGPUChainedStructOut chain;
     uint32_t maxPushConstantSize;
     uint32_t maxNonSamplerBindings;
 } WGPUNativeLimits;
 
-typedef struct WGPURequiredLimitsExtras {
-    WGPUChainedStruct chain;
-    WGPUNativeLimits limits;
-} WGPURequiredLimitsExtras;
-
-typedef struct WGPUSupportedLimitsExtras {
-    WGPUChainedStructOut chain;
-    WGPUNativeLimits limits;
-} WGPUSupportedLimitsExtras;
-
 typedef struct WGPUPushConstantRange {
-    WGPUShaderStageFlags stages;
+    WGPUShaderStage stages;
     uint32_t start;
     uint32_t end;
 } WGPUPushConstantRange;
@@ -165,29 +154,29 @@ typedef struct WGPUPipelineLayoutExtras {
 
 typedef uint64_t WGPUSubmissionIndex;
 
-typedef struct WGPUWrappedSubmissionIndex {
-    WGPUQueue queue;
-    WGPUSubmissionIndex submissionIndex;
-} WGPUWrappedSubmissionIndex;
-
 typedef struct WGPUShaderDefine {
-    char const * name;
-    char const * value;
+    WGPUStringView name;
+    WGPUStringView value;
 } WGPUShaderDefine;
 
 typedef struct WGPUShaderModuleGLSLDescriptor {
     WGPUChainedStruct chain;
     WGPUShaderStage stage;
-    char const * code;
+    WGPUStringView code;
     uint32_t defineCount;
     WGPUShaderDefine * defines;
 } WGPUShaderModuleGLSLDescriptor;
+
+typedef struct WGPUShaderModuleDescriptorSpirV {
+    WGPUStringView label;
+    uint32_t sourceSize;
+    uint32_t const * source;
+} WGPUShaderModuleDescriptorSpirV;
 
 typedef struct WGPURegistryReport {
    size_t numAllocated;
    size_t numKeptFromUser;
    size_t numReleasedFromUser;
-   size_t numError;
    size_t elementSize;
 } WGPURegistryReport;
 
@@ -203,6 +192,7 @@ typedef struct WGPUHubReport {
     WGPURegistryReport renderBundles;
     WGPURegistryReport renderPipelines;
     WGPURegistryReport computePipelines;
+    WGPURegistryReport pipelineCaches;
     WGPURegistryReport querySets;
     WGPURegistryReport buffers;
     WGPURegistryReport textures;
@@ -212,16 +202,12 @@ typedef struct WGPUHubReport {
 
 typedef struct WGPUGlobalReport {
     WGPURegistryReport surfaces;
-    WGPUBackendType backendType;
-    WGPUHubReport vulkan;
-    WGPUHubReport metal;
-    WGPUHubReport dx12;
-    WGPUHubReport gl;
+    WGPUHubReport hub;
 } WGPUGlobalReport;
 
 typedef struct WGPUInstanceEnumerateAdapterOptions {
     WGPUChainedStruct const * nextInChain;
-    WGPUInstanceBackendFlags backends;
+    WGPUInstanceBackend backends;
 } WGPUInstanceEnumerateAdapterOptions;
 
 typedef struct WGPUBindGroupEntryExtras {
@@ -247,10 +233,10 @@ typedef struct WGPUQuerySetDescriptorExtras {
 
 typedef struct WGPUSurfaceConfigurationExtras {
     WGPUChainedStruct chain;
-    WGPUBool desiredMaximumFrameLatency;
+    uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras WGPU_STRUCTURE_ATTRIBUTE;
 
-typedef void (*WGPULogCallback)(WGPULogLevel level, char const * message, void * userdata);
+typedef void (*WGPULogCallback)(WGPULogLevel level, WGPUStringView message, void * userdata);
 
 typedef enum WGPUNativeTextureFormat {
     // From Features::TEXTURE_FORMAT_16BIT_NORM
@@ -274,7 +260,8 @@ size_t wgpuInstanceEnumerateAdapters(WGPUInstance instance, WGPU_NULLABLE WGPUIn
 WGPUSubmissionIndex wgpuQueueSubmitForIndex(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands);
 
 // Returns true if the queue is empty, or false if there are more queue submissions still in flight.
-WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUWrappedSubmissionIndex const * wrappedSubmissionIndex);
+WGPUBool wgpuDevicePoll(WGPUDevice device, WGPUBool wait, WGPU_NULLABLE WGPUSubmissionIndex const * wrappedSubmissionIndex);
+WGPUShaderModule wgpuDeviceCreateShaderModuleSpirV(WGPUDevice device, WGPUShaderModuleDescriptorSpirV const * descriptor);
 
 void wgpuSetLogCallback(WGPULogCallback callback, void * userdata);
 
@@ -282,7 +269,9 @@ void wgpuSetLogLevel(WGPULogLevel level);
 
 uint32_t wgpuGetVersion(void);
 
-void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuRenderPassEncoderSetPushConstants(WGPURenderPassEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuComputePassEncoderSetPushConstants(WGPUComputePassEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const * data);
+void wgpuRenderBundleEncoderSetPushConstants(WGPURenderBundleEncoder encoder, WGPUShaderStage stages, uint32_t offset, uint32_t sizeBytes, void const * data);
 
 void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
@@ -294,6 +283,9 @@ void wgpuComputePassEncoderBeginPipelineStatisticsQuery(WGPUComputePassEncoder c
 void wgpuComputePassEncoderEndPipelineStatisticsQuery(WGPUComputePassEncoder computePassEncoder);
 void wgpuRenderPassEncoderBeginPipelineStatisticsQuery(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 void wgpuRenderPassEncoderEndPipelineStatisticsQuery(WGPURenderPassEncoder renderPassEncoder);
+
+void wgpuComputePassEncoderWriteTimestamp(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+void wgpuRenderPassEncoderWriteTimestamp(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/wgpu/queue.go
+++ b/wgpu/queue.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 extern void gowebgpu_queue_work_done_callback_c(WGPUQueueWorkDoneStatus status, void * userdata);

--- a/wgpu/queue.go
+++ b/wgpu/queue.go
@@ -67,7 +67,7 @@ func (p *Queue) OnSubmittedWorkDone(callback QueueWorkDoneCallback) {
 	handle := cgo.NewHandle(callback)
 
 	C.wgpuQueueOnSubmittedWorkDone(p.ref, C.WGPUQueueWorkDoneCallbackInfo{
-		callback:  C.gowebgpu_queue_work_done_callback_c,
+		callback:  C.WGPUQueueWorkDoneCallback(C.gowebgpu_queue_work_done_callback_c),
 		userdata1: unsafe.Pointer(&handle),
 	})
 }

--- a/wgpu/render_bundle_encoder.go
+++ b/wgpu/render_bundle_encoder.go
@@ -64,7 +64,7 @@ func (p *RenderBundleEncoder) Finish(descriptor *RenderBundleDescriptor) *Render
 		defer C.free(unsafe.Pointer(label))
 
 		desc = &C.WGPURenderBundleDescriptor{
-			label: label,
+			label: C.WGPUStringView{data: label, length: C.WGPU_STRLEN},
 		}
 	}
 
@@ -79,7 +79,10 @@ func (p *RenderBundleEncoder) InsertDebugMarker(markerLabel string) {
 	markerLabelStr := C.CString(markerLabel)
 	defer C.free(unsafe.Pointer(markerLabelStr))
 
-	C.wgpuRenderBundleEncoderInsertDebugMarker(p.ref, markerLabelStr)
+	C.wgpuRenderBundleEncoderInsertDebugMarker(p.ref, C.WGPUStringView{
+		data:   markerLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *RenderBundleEncoder) PopDebugGroup() {
@@ -90,7 +93,10 @@ func (p *RenderBundleEncoder) PushDebugGroup(groupLabel string) {
 	groupLabelStr := C.CString(groupLabel)
 	defer C.free(unsafe.Pointer(groupLabelStr))
 
-	C.wgpuRenderBundleEncoderPushDebugGroup(p.ref, groupLabelStr)
+	C.wgpuRenderBundleEncoderPushDebugGroup(p.ref, C.WGPUStringView{
+		data:   groupLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *RenderBundleEncoder) SetBindGroup(groupIndex uint32, group *BindGroup, dynamicOffsets []uint32) {

--- a/wgpu/render_bundle_encoder.go
+++ b/wgpu/render_bundle_encoder.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 */
 import "C"

--- a/wgpu/render_pass_encoder.go
+++ b/wgpu/render_pass_encoder.go
@@ -119,7 +119,10 @@ func (p *RenderPassEncoder) InsertDebugMarker(markerLabel string) {
 	markerLabelStr := C.CString(markerLabel)
 	defer C.free(unsafe.Pointer(markerLabelStr))
 
-	C.wgpuRenderPassEncoderInsertDebugMarker(p.ref, markerLabelStr)
+	C.wgpuRenderPassEncoderInsertDebugMarker(p.ref, C.WGPUStringView{
+		data:   markerLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *RenderPassEncoder) PopDebugGroup() {
@@ -130,7 +133,10 @@ func (p *RenderPassEncoder) PushDebugGroup(groupLabel string) {
 	groupLabelStr := C.CString(groupLabel)
 	defer C.free(unsafe.Pointer(groupLabelStr))
 
-	C.wgpuRenderPassEncoderPushDebugGroup(p.ref, groupLabelStr)
+	C.wgpuRenderPassEncoderPushDebugGroup(p.ref, C.WGPUStringView{
+		data:   groupLabelStr,
+		length: C.WGPU_STRLEN,
+	})
 }
 
 func (p *RenderPassEncoder) SetBindGroup(groupIndex uint32, group *BindGroup, dynamicOffsets []uint32) {

--- a/wgpu/render_pass_encoder.go
+++ b/wgpu/render_pass_encoder.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 

--- a/wgpu/render_pipeline.go
+++ b/wgpu/render_pipeline.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 */
 import "C"

--- a/wgpu/surface.go
+++ b/wgpu/surface.go
@@ -7,13 +7,20 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
 static inline WGPUTexture gowebgpu_surface_get_current_texture(WGPUSurface surface, WGPUDevice device, void * error_userdata) {
 	WGPUSurfaceTexture ref;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	wgpuSurfaceGetCurrentTexture(surface, &ref);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref.texture;
 }
 
@@ -79,7 +86,7 @@ func (p *Surface) Configure(adapter *Adapter, device *Device, config *SurfaceCon
 		cfg = &C.WGPUSurfaceConfiguration{
 			device:      p.deviceRef,
 			format:      C.WGPUTextureFormat(config.Format),
-			usage:       C.WGPUTextureUsageFlags(config.Usage),
+			usage:       C.WGPUTextureUsage(config.Usage),
 			alphaMode:   C.WGPUCompositeAlphaMode(config.AlphaMode),
 			width:       C.uint32_t(config.Width),
 			height:      C.uint32_t(config.Height),

--- a/wgpu/surface.go
+++ b/wgpu/surface.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 

--- a/wgpu/texture.go
+++ b/wgpu/texture.go
@@ -60,7 +60,8 @@ func (p *Texture) CreateView(descriptor *TextureViewDescriptor) (*TextureView, e
 			label := C.CString(descriptor.Label)
 			defer C.free(unsafe.Pointer(label))
 
-			desc.label = label
+			desc.label.data = label
+			desc.label.length = C.WGPU_STRLEN
 		}
 	}
 

--- a/wgpu/texture.go
+++ b/wgpu/texture.go
@@ -5,7 +5,7 @@ package wgpu
 /*
 
 #include <stdlib.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 

--- a/wgpu/texture.go
+++ b/wgpu/texture.go
@@ -7,13 +7,20 @@ package wgpu
 #include <stdlib.h>
 #include "./lib/wgpu.h"
 
-extern void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata);
+extern void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2);
 
 static inline WGPUTextureView gowebgpu_texture_create_view(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor, WGPUDevice device, void * error_userdata) {
 	WGPUTextureView ref = NULL;
 	wgpuDevicePushErrorScope(device, WGPUErrorFilter_Validation);
 	ref = wgpuTextureCreateView(texture, descriptor);
-	wgpuDevicePopErrorScope(device, gowebgpu_error_callback_c, error_userdata);
+
+	WGPUPopErrorScopeCallbackInfo const err_cb = {
+		.callback = gowebgpu_error_callback_c,
+		.userdata1 = error_userdata,
+	};
+
+	wgpuDevicePopErrorScope(device, err_cb);
+
 	return ref;
 }
 

--- a/wgpu/texture_ext.go
+++ b/wgpu/texture_ext.go
@@ -1,7 +1,7 @@
 package wgpu
 
-func (p *Texture) AsImageCopy() *ImageCopyTexture {
-	return &ImageCopyTexture{
+func (p *Texture) AsImageCopy() *TexelCopyTextureInfo {
+	return &TexelCopyTextureInfo{
 		Texture:  p,
 		MipLevel: 0,
 		Origin:   Origin3D{},

--- a/wgpu/wgpu.go
+++ b/wgpu/wgpu.go
@@ -24,10 +24,11 @@ package wgpu
 
 // Darwin
 #cgo darwin,!ios,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin/amd64 -lwgpu_native
+#cgo darwin,!ios,amd64 CFLAGS: -I${SRCDIR}/lib/darwin/amd64
 #cgo darwin,!ios,arm64 LDFLAGS: -L${SRCDIR}/lib/darwin/arm64 -lwgpu_native
 #cgo darwin,!ios,arm64 CFLAGS: -I${SRCDIR}/lib/darwin/arm64
 
-#cgo darwin LDFLAGS: -framework QuartzCore -framework Metal
+#cgo darwin LDFLAGS: -framework Metal -framework QuartzCore
 
 // Windows
 #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/lib/windows/amd64 -lwgpu_native

--- a/wgpu/wgpu.go
+++ b/wgpu/wgpu.go
@@ -25,6 +25,7 @@ package wgpu
 // Darwin
 #cgo darwin,!ios,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin/amd64 -lwgpu_native
 #cgo darwin,!ios,arm64 LDFLAGS: -L${SRCDIR}/lib/darwin/arm64 -lwgpu_native
+#cgo darwin,!ios,arm64 CFLAGS: -I${SRCDIR}/lib/darwin/arm64
 
 #cgo darwin LDFLAGS: -framework QuartzCore -framework Metal
 
@@ -35,7 +36,7 @@ package wgpu
 #cgo windows LDFLAGS: -lopengl32 -lgdi32 -ld3dcompiler_47 -lws2_32 -luserenv -lbcrypt -lntdll
 
 #include <stdio.h>
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 #ifdef __ANDROID__
 #include <android/log.h>

--- a/wgpu/wgpu.go
+++ b/wgpu/wgpu.go
@@ -6,21 +6,29 @@ package wgpu
 
 // Android
 #cgo android,amd64 LDFLAGS: -L${SRCDIR}/lib/android/amd64 -lwgpu_native
+#cgo android,amd64 CFLAGS: -I${SRCDIR}/lib/android/amd64
 #cgo android,386 LDFLAGS: -L${SRCDIR}/lib/android/386 -lwgpu_native
+#cgo android,386 CFLAGS: -I${SRCDIR}/lib/android/386
 #cgo android,arm64 LDFLAGS: -L${SRCDIR}/lib/android/arm64 -lwgpu_native
+#cgo android,arm64 CFLAGS: -I${SRCDIR}/lib/android/arm64
 #cgo android,arm LDFLAGS: -L${SRCDIR}/lib/android/arm -lwgpu_native
+#cgo android,arm CFLAGS: -I${SRCDIR}/lib/android/arm
 
 #cgo android LDFLAGS: -landroid -lm -llog
 
 // Linux
 #cgo linux,!android,amd64 LDFLAGS: -L${SRCDIR}/lib/linux/amd64 -lwgpu_native
+#cgo linux,!android,amd64 CFLAGS: -I${SRCDIR}/lib/linux/amd64
 #cgo linux,!android,arm64 LDFLAGS: -L${SRCDIR}/lib/linux/arm64 -lwgpu_native
+#cgo linux,!android,arm64 CFLAGS: -I${SRCDIR}/lib/linux/arm64
 
 #cgo linux,!android LDFLAGS: -lm -ldl
 
 // iOS
 #cgo ios,amd64 LDFLAGS: -L${SRCDIR}/lib/ios/amd64 -lwgpu_native
+#cgo ios,amd64 CFLAGS: -I${SRCDIR}/lib/ios/amd64
 #cgo ios,arm64 LDFLAGS: -L${SRCDIR}/lib/ios/arm64 -lwgpu_native
+#cgo ios,arm64 CFLAGS: -I${SRCDIR}/lib/ios/arm64
 
 // Darwin
 #cgo darwin,!ios,amd64 LDFLAGS: -L${SRCDIR}/lib/darwin/amd64 -lwgpu_native
@@ -32,7 +40,11 @@ package wgpu
 
 // Windows
 #cgo windows,amd64 LDFLAGS: -L${SRCDIR}/lib/windows/amd64 -lwgpu_native
+#cgo windows,amd64 CFLAGS: -I${SRCDIR}/lib/windows/amd64
 #cgo windows,arm64 LDFLAGS: -L${SRCDIR}/lib/windows/arm64 -lwgpu_native
+#cgo windows,arm64 CFLAGS: -I${SRCDIR}/lib/windows/arm64
+#cgo windows,386 LDFLAGS: -L${SRCDIR}/lib/windows/386 -lwgpu_native
+#cgo windows,386 CFLAGS: -I${SRCDIR}/lib/windows/386
 
 #cgo windows LDFLAGS: -lopengl32 -lgdi32 -ld3dcompiler_47 -lws2_32 -luserenv -lbcrypt -lntdll
 

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -6,7 +6,7 @@ package wgpu
 
 #include <wgpu.h>
 
-void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata) {
+void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, WGPUStringView message, void *userdata, void *userdata2) {
   extern void gowebgpu_buffer_map_callback_go(WGPUMapAsyncStatus status, void *userdata);
   gowebgpu_buffer_map_callback_go(status, userdata);
 }

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -6,8 +6,8 @@ package wgpu
 
 #include "./lib/wgpu.h"
 
-void gowebgpu_buffer_map_callback_c(WGPUBufferMapAsyncStatus status, void *userdata) {
-  extern void gowebgpu_buffer_map_callback_go(WGPUBufferMapAsyncStatus status, void *userdata);
+void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata) {
+  extern void gowebgpu_buffer_map_callback_go(WGPUMapAsyncStatus status, void *userdata);
   gowebgpu_buffer_map_callback_go(status, userdata);
 }
 
@@ -31,7 +31,7 @@ void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorTyp
     return;
   }
 
-  extern void gowebgpu_error_callback_go(WGPUErrorType type, char const * message, void * userdata);
+  extern void gowebgpu_error_callback_go(WGPUErrorType type, WGPUStringView message, void * userdata);
   gowebgpu_error_callback_go(type, message, userdata);
 }
 

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -16,9 +16,9 @@ void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAd
   gowebgpu_request_adapter_callback_go(status, adapter, message, userdata1);
 }
 
-void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, char const *message, void *userdata) {
-  extern void gowebgpu_request_device_callback_go(WGPURequestDeviceStatus status, WGPUDevice device, char const *message, void *userdata);
-  gowebgpu_request_device_callback_go(status, device, message, userdata);
+void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void *userdata1, void *userdata2) {
+  extern void gowebgpu_request_device_callback_go(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void *userdata);
+  gowebgpu_request_device_callback_go(status, device, message, userdata1);
 }
 
 void gowebgpu_device_lost_callback_c(WGPUDeviceLostReason reason, char const * message, void * userdata) {

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -4,7 +4,7 @@ package wgpu
 
 /*
 
-#include "./lib/wgpu.h"
+#include <wgpu.h>
 
 void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata) {
   extern void gowebgpu_buffer_map_callback_go(WGPUMapAsyncStatus status, void *userdata);

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -11,9 +11,9 @@ void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, void *userdata) {
   gowebgpu_buffer_map_callback_go(status, userdata);
 }
 
-void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAdapter adapter, char const *message, void *userdata) {
-  extern void gowebgpu_request_adapter_callback_go(WGPURequestAdapterStatus status, WGPUAdapter adapter, char const *message, void *userdata);
-  gowebgpu_request_adapter_callback_go(status, adapter, message, userdata);
+void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void *userdata1, void *userdata2) {
+  extern void gowebgpu_request_adapter_callback_go(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void *userdata);
+  gowebgpu_request_adapter_callback_go(status, adapter, message, userdata1);
 }
 
 void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, char const *message, void *userdata) {

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -6,18 +6,18 @@ package wgpu
 
 #include <wgpu.h>
 
-void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, WGPUStringView message, void *userdata, void *userdata2) {
-  extern void gowebgpu_buffer_map_callback_go(WGPUMapAsyncStatus status, void *userdata);
+void gowebgpu_buffer_map_callback_c(WGPUMapAsyncStatus status, WGPUStringView message, void * userdata, void * userdata2) {
+  extern void gowebgpu_buffer_map_callback_go(WGPUMapAsyncStatus status, void * userdata);
   gowebgpu_buffer_map_callback_go(status, userdata);
 }
 
-void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void *userdata1, void *userdata2) {
-  extern void gowebgpu_request_adapter_callback_go(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void *userdata);
+void gowebgpu_request_adapter_callback_c(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void * userdata1, void * userdata2) {
+  extern void gowebgpu_request_adapter_callback_go(WGPURequestAdapterStatus status, WGPUAdapter adapter, WGPUStringView message, void * userdata);
   gowebgpu_request_adapter_callback_go(status, adapter, message, userdata1);
 }
 
-void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void *userdata1, void *userdata2) {
-  extern void gowebgpu_request_device_callback_go(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void *userdata);
+void gowebgpu_request_device_callback_c(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void * userdata1, void * userdata2) {
+  extern void gowebgpu_request_device_callback_go(WGPURequestDeviceStatus status, WGPUDevice device, WGPUStringView message, void * userdata);
   gowebgpu_request_device_callback_go(status, device, message, userdata1);
 }
 

--- a/wgpu/wgpu_c_cb.go
+++ b/wgpu/wgpu_c_cb.go
@@ -26,7 +26,7 @@ void gowebgpu_device_lost_callback_c(WGPUDeviceLostReason reason, char const * m
   gowebgpu_device_lost_callback_go(reason, message, userdata);
 }
 
-void gowebgpu_error_callback_c(WGPUErrorType type, char const * message, void * userdata) {
+void gowebgpu_error_callback_c(enum WGPUPopErrorScopeStatus status, WGPUErrorType type, WGPUStringView message, void * userdata, void * userdata2) {
   if (type == WGPUErrorType_NoError) {
     return;
   }

--- a/wgpuglfw/surface_darwin.go
+++ b/wgpuglfw/surface_darwin.go
@@ -31,7 +31,7 @@ import "C"
 
 func GetSurfaceDescriptor(w *glfw.Window) *wgpu.SurfaceDescriptor {
 	return &wgpu.SurfaceDescriptor{
-		MetalLayer: &wgpu.SurfaceDescriptorFromMetalLayer{
+		MetalLayer: &wgpu.SurfaceSourceMetalLayer{
 			Layer: unsafe.Pointer(C.metalLayerFromNSWindow((C.CFTypeRef)(unsafe.Pointer(w.GetCocoaWindow())))),
 		},
 	}

--- a/wgpuglfw/surface_wayland_linux.go
+++ b/wgpuglfw/surface_wayland_linux.go
@@ -11,7 +11,7 @@ import (
 
 func GetSurfaceDescriptor(w *glfw.Window) *wgpu.SurfaceDescriptor {
 	return &wgpu.SurfaceDescriptor{
-		WaylandSurface: &wgpu.SurfaceDescriptorFromWaylandSurface{
+		WaylandSurface: &wgpu.SurfaceSourceWaylandSurface{
 			Display: unsafe.Pointer(glfw.GetWaylandDisplay()),
 			Surface: unsafe.Pointer(w.GetWaylandWindow()),
 		},

--- a/wgpuglfw/surface_windows.go
+++ b/wgpuglfw/surface_windows.go
@@ -18,7 +18,7 @@ import "C"
 
 func GetSurfaceDescriptor(w *glfw.Window) *wgpu.SurfaceDescriptor {
 	return &wgpu.SurfaceDescriptor{
-		WindowsHWND: &wgpu.SurfaceDescriptorFromWindowsHWND{
+		WindowsHWND: &wgpu.SurfaceSourceWindowsHWND{
 			Hwnd:      unsafe.Pointer(w.GetWin32Window()),
 			Hinstance: unsafe.Pointer(C.GetModuleHandle(nil)),
 		},

--- a/wgpuglfw/surface_x11_linux.go
+++ b/wgpuglfw/surface_x11_linux.go
@@ -11,7 +11,7 @@ import (
 
 func GetSurfaceDescriptor(w *glfw.Window) *wgpu.SurfaceDescriptor {
 	return &wgpu.SurfaceDescriptor{
-		XlibWindow: &wgpu.SurfaceDescriptorFromXlibWindow{
+		XlibWindow: &wgpu.SurfaceSourceXlibWindow{
 			Display: unsafe.Pointer(glfw.GetX11Display()),
 			Window:  uint32(w.GetX11Window()),
 		},


### PR DESCRIPTION
This updates to [wgpu-native](https://github.com/gfx-rs/wgpu-native) v25.0.2.1 (current latest), building on the great work that @obiwac did to update the code in his earlier PR #4. It is now fully tested and working on all the cogentcore.org uses of webgpu (fairly extensive, including graphics and compute), but the libraries (which are very large collectively) are not committed:

* Use `getrelease.goal` for current mechanism to get the released `wgpu-native` libraries downloaded and installed. The libraries will be committed to this repo when v26 comes out, but for now, this is required. This requires:
* gh tool: https://github.com/cli/cli with authentication configured.
* goal: `go install cogentcore.org/lab/goal/cmd/goal@main`
