### PR TITLE
instance: Fix uninitialized memory

### DIFF
--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -25,7 +25,7 @@ func CreateInstance(descriptor *InstanceDescriptor) *Instance {
 	var desc C.WGPUInstanceDescriptor
 
 	if descriptor != nil {
-		instanceExtras := (*C.WGPUInstanceExtras)(C.malloc(C.size_t(unsafe.Sizeof(C.WGPUInstanceExtras{}))))
+		instanceExtras := (*C.WGPUInstanceExtras)(C.calloc(1, C.size_t(unsafe.Sizeof(C.WGPUInstanceExtras{}))))
 		defer C.free(unsafe.Pointer(instanceExtras))
 
 		instanceExtras.chain.next = nil


### PR DESCRIPTION
The conversion from the Go type to the C type assumes this memory is zeroed. But it might not be zeroed, in which case conversion back from C to Rust will fail in `webgpu-native` (specifically in `map_instance_descriptor`).

There might be other places where memory is meant to be zeroed but isn't - I'll go through all `malloc` calls when I have time :)