### PR TITLE
Memory corruption panic in async callbacks fix

### DIFF
--- a/wgpu/adapter.go
+++ b/wgpu/adapter.go
@@ -108,9 +108,8 @@ type requestDeviceCb func(status RequestDeviceStatus, device *Device, message st
 
 //export gowebgpu_request_device_callback_go
 func gowebgpu_request_device_callback_go(status C.WGPURequestDeviceStatus, device C.WGPUDevice, message *C.char, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	defer handle.Delete()
-
 	cb, ok := handle.Value().(requestDeviceCb)
 	if ok {
 		cb(RequestDeviceStatus(status), &Device{ref: device}, C.GoString(message))
@@ -119,9 +118,8 @@ func gowebgpu_request_device_callback_go(status C.WGPURequestDeviceStatus, devic
 
 //export gowebgpu_device_lost_callback_go
 func gowebgpu_device_lost_callback_go(reason C.WGPUDeviceLostReason, message *C.char, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	defer handle.Delete()
-
 	cb, ok := handle.Value().(DeviceLostCallback)
 	if ok {
 		cb(DeviceLostReason(reason), C.GoString(message))
@@ -206,7 +204,7 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 			handle := cgo.NewHandle(descriptor.DeviceLostCallback)
 
 			desc.deviceLostCallback = C.WGPUDeviceLostCallback(C.gowebgpu_device_lost_callback_c)
-			desc.deviceLostUserdata = unsafe.Pointer(&handle)
+			desc.deviceLostUserdata = unsafe.Pointer(handle)
 		}
 
 		if descriptor.TracePath != "" {
@@ -233,7 +231,7 @@ func (p *Adapter) RequestDevice(descriptor *DeviceDescriptor) (*Device, error) {
 		device = d
 	}
 	handle := cgo.NewHandle(cb)
-	C.wgpuAdapterRequestDevice(p.ref, desc, C.WGPUAdapterRequestDeviceCallback(C.gowebgpu_request_device_callback_c), unsafe.Pointer(&handle))
+	C.wgpuAdapterRequestDevice(p.ref, desc, C.WGPUAdapterRequestDeviceCallback(C.gowebgpu_request_device_callback_c), unsafe.Pointer(handle))
 
 	if status != RequestDeviceStatusSuccess {
 		return nil, errors.New("failed to request device")

--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -59,7 +59,7 @@ func (p *Buffer) GetUsage() BufferUsage {
 
 //export gowebgpu_buffer_map_callback_go
 func gowebgpu_buffer_map_callback_go(status C.WGPUBufferMapAsyncStatus, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(BufferMapCallback)
@@ -83,9 +83,9 @@ func (p *Buffer) MapAsync(mode MapMode, offset uint64, size uint64, callback Buf
 		C.size_t(offset),
 		C.size_t(size),
 		(C.WGPUBufferMapAsyncCallback)(C.gowebgpu_buffer_map_callback_c),
-		unsafe.Pointer(&callbackHandle),
+		unsafe.Pointer(callbackHandle),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -100,7 +100,7 @@ func (p *Buffer) Unmap() (err error) {
 	C.gowebgpu_buffer_unmap(
 		p.ref,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }

--- a/wgpu/command_encoder.go
+++ b/wgpu/command_encoder.go
@@ -205,7 +205,7 @@ func (p *CommandEncoder) ClearBuffer(buffer *Buffer, offset uint64, size uint64)
 		C.uint64_t(offset),
 		C.uint64_t(size),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -225,7 +225,7 @@ func (p *CommandEncoder) CopyBufferToBuffer(source *Buffer, sourceOffset uint64,
 		C.uint64_t(destinatonOffset),
 		C.uint64_t(size),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -280,7 +280,7 @@ func (p *CommandEncoder) CopyBufferToTexture(source *ImageCopyBuffer, destinatio
 		&dst,
 		&cpySize,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -335,7 +335,7 @@ func (p *CommandEncoder) CopyTextureToBuffer(source *ImageCopyTexture, destinati
 		&dst,
 		&cpySize,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -394,7 +394,7 @@ func (p *CommandEncoder) CopyTextureToTexture(source *ImageCopyTexture, destinat
 		&dst,
 		&cpySize,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -422,7 +422,7 @@ func (p *CommandEncoder) Finish(descriptor *CommandBufferDescriptor) (*CommandBu
 		p.ref,
 		desc,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuCommandBufferRelease(ref)
@@ -446,7 +446,7 @@ func (p *CommandEncoder) InsertDebugMarker(markerLabel string) (err error) {
 		p.ref,
 		markerLabelStr,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -461,7 +461,7 @@ func (p *CommandEncoder) PopDebugGroup() (err error) {
 	C.gowebgpu_command_encoder_pop_debug_group(
 		p.ref,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -480,7 +480,7 @@ func (p *CommandEncoder) PushDebugGroup(groupLabel string) (err error) {
 		p.ref,
 		groupLabelStr,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -500,7 +500,7 @@ func (p *CommandEncoder) ResolveQuerySet(querySet *QuerySet, firstQuery uint32, 
 		destination.ref,
 		C.uint64_t(destinationOffset),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -517,7 +517,7 @@ func (p *CommandEncoder) WriteTimestamp(querySet *QuerySet, queryIndex uint32) (
 		querySet.ref,
 		C.uint32_t(queryIndex),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }

--- a/wgpu/compute_pass_encoder.go
+++ b/wgpu/compute_pass_encoder.go
@@ -52,7 +52,7 @@ func (p *ComputePassEncoder) End() (err error) {
 	errorCallbackHandle := cgo.NewHandle(cb)
 	defer errorCallbackHandle.Delete()
 
-	C.gowebgpu_compute_pass_encoder_end(p.ref, p.deviceRef, unsafe.Pointer(&errorCallbackHandle))
+	C.gowebgpu_compute_pass_encoder_end(p.ref, p.deviceRef, unsafe.Pointer(errorCallbackHandle))
 	return
 }
 

--- a/wgpu/device.go
+++ b/wgpu/device.go
@@ -113,7 +113,7 @@ type errorCallback func(typ ErrorType, message string)
 
 //export gowebgpu_error_callback_go
 func gowebgpu_error_callback_go(_type C.WGPUErrorType, message *C.char, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	cb, ok := handle.Value().(errorCallback)
 	if ok {
 		cb(ErrorType(_type), C.GoString(message))
@@ -179,7 +179,7 @@ func (p *Device) CreateBindGroup(descriptor *BindGroupDescriptor) (*BindGroup, e
 	ref := C.gowebgpu_device_create_bind_group(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuBindGroupRelease(ref)
@@ -283,7 +283,7 @@ func (p *Device) CreateBindGroupLayout(descriptor *BindGroupLayoutDescriptor) (*
 	ref := C.gowebgpu_device_create_bind_group_layout(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuBindGroupLayoutRelease(ref)
@@ -319,7 +319,7 @@ func (p *Device) CreateBuffer(descriptor *BufferDescriptor) (*Buffer, error) {
 	ref := C.gowebgpu_device_create_buffer(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuBufferRelease(ref)
@@ -352,7 +352,7 @@ func (p *Device) CreateCommandEncoder(descriptor *CommandEncoderDescriptor) (*Co
 	ref := C.gowebgpu_device_create_command_encoder(
 		p.ref,
 		desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuCommandEncoderRelease(ref)
@@ -412,7 +412,7 @@ func (p *Device) CreateComputePipeline(descriptor *ComputePipelineDescriptor) (*
 	ref := C.gowebgpu_device_create_compute_pipeline(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuComputePipelineRelease(ref)
@@ -500,7 +500,7 @@ func (p *Device) CreatePipelineLayout(descriptor *PipelineLayoutDescriptor) (*Pi
 	ref := C.gowebgpu_device_create_pipeline_layout(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuPipelineLayoutRelease(ref)
@@ -554,7 +554,7 @@ func (p *Device) CreateQuerySet(descriptor *QuerySetDescriptor) (*QuerySet, erro
 	ref := C.gowebgpu_device_create_query_set(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuQuerySetRelease(ref)
@@ -863,7 +863,7 @@ func (p *Device) CreateRenderPipeline(descriptor *RenderPipelineDescriptor) (*Re
 				frag.targets = nil
 			}
 			frag.constantCount = 0 // note: crashes on linux arm64 without setting this to 0
-			frag.constants = nil // even though wgpu doesn't even support it.
+			frag.constants = nil   // even though wgpu doesn't even support it.
 
 			desc.fragment = frag
 		}
@@ -879,7 +879,7 @@ func (p *Device) CreateRenderPipeline(descriptor *RenderPipelineDescriptor) (*Re
 	ref := C.gowebgpu_device_create_render_pipeline(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuRenderPipelineRelease(ref)
@@ -924,7 +924,7 @@ func (p *Device) CreateSampler(descriptor *SamplerDescriptor) (*Sampler, error) 
 	ref := C.gowebgpu_device_create_sampler(
 		p.ref,
 		desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuSamplerRelease(ref)
@@ -1061,7 +1061,7 @@ func (p *Device) CreateShaderModule(descriptor *ShaderModuleDescriptor) (*Shader
 	ref := C.gowebgpu_device_create_shader_module(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuShaderModuleRelease(ref)
@@ -1106,7 +1106,7 @@ func (p *Device) CreateTexture(descriptor *TextureDescriptor) (*Texture, error) 
 	ref := C.gowebgpu_device_create_texture(
 		p.ref,
 		&desc,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuTextureRelease(ref)

--- a/wgpu/instance.go
+++ b/wgpu/instance.go
@@ -188,7 +188,7 @@ type requestAdapterCb func(status RequestAdapterStatus, adapter *Adapter, messag
 
 //export gowebgpu_request_adapter_callback_go
 func gowebgpu_request_adapter_callback_go(status C.WGPURequestAdapterStatus, adapter C.WGPUAdapter, message *C.char, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(requestAdapterCb)
@@ -219,7 +219,7 @@ func (p *Instance) RequestAdapter(options *RequestAdapterOptions) (*Adapter, err
 		adapter = a
 	}
 	handle := cgo.NewHandle(cb)
-	C.wgpuInstanceRequestAdapter(p.ref, opts, C.WGPUInstanceRequestAdapterCallback(C.gowebgpu_request_adapter_callback_c), unsafe.Pointer(&handle))
+	C.wgpuInstanceRequestAdapter(p.ref, opts, C.WGPUInstanceRequestAdapterCallback(C.gowebgpu_request_adapter_callback_c), unsafe.Pointer(handle))
 
 	if status != RequestAdapterStatusSuccess {
 		return nil, errors.New("failed to request adapter")

--- a/wgpu/queue.go
+++ b/wgpu/queue.go
@@ -42,7 +42,7 @@ type Queue struct {
 
 //export gowebgpu_queue_work_done_callback_go
 func gowebgpu_queue_work_done_callback_go(status C.WGPUQueueWorkDoneStatus, userdata unsafe.Pointer) {
-	handle := *(*cgo.Handle)(userdata)
+	handle := cgo.Handle(userdata)
 	defer handle.Delete()
 
 	cb, ok := handle.Value().(QueueWorkDoneCallback)
@@ -54,7 +54,7 @@ func gowebgpu_queue_work_done_callback_go(status C.WGPUQueueWorkDoneStatus, user
 func (p *Queue) OnSubmittedWorkDone(callback QueueWorkDoneCallback) {
 	handle := cgo.NewHandle(callback)
 
-	C.wgpuQueueOnSubmittedWorkDone(p.ref, C.WGPUQueueOnSubmittedWorkDoneCallback(C.gowebgpu_queue_work_done_callback_c), unsafe.Pointer(&handle))
+	C.wgpuQueueOnSubmittedWorkDone(p.ref, C.WGPUQueueOnSubmittedWorkDoneCallback(C.gowebgpu_queue_work_done_callback_c), unsafe.Pointer(handle))
 }
 
 func (p *Queue) Submit(commands ...*CommandBuffer) (submissionIndex SubmissionIndex) {
@@ -96,7 +96,7 @@ func (p *Queue) WriteBuffer(buffer *Buffer, bufferOffset uint64, data []byte) (e
 			nil,
 			0,
 			p.deviceRef,
-			unsafe.Pointer(&errorCallbackHandle),
+			unsafe.Pointer(errorCallbackHandle),
 		)
 		return
 	}
@@ -108,7 +108,7 @@ func (p *Queue) WriteBuffer(buffer *Buffer, bufferOffset uint64, data []byte) (e
 		unsafe.Pointer(&data[0]),
 		C.size_t(size),
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }
@@ -164,7 +164,7 @@ func (p *Queue) WriteTexture(destination *ImageCopyTexture, data []byte, dataLay
 			&layout,
 			&writeExtent,
 			p.deviceRef,
-			unsafe.Pointer(&errorCallbackHandle),
+			unsafe.Pointer(errorCallbackHandle),
 		)
 		return
 	}
@@ -177,7 +177,7 @@ func (p *Queue) WriteTexture(destination *ImageCopyTexture, data []byte, dataLay
 		&layout,
 		&writeExtent,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }

--- a/wgpu/render_pass_encoder.go
+++ b/wgpu/render_pass_encoder.go
@@ -78,7 +78,7 @@ func (p *RenderPassEncoder) End() (err error) {
 	C.gowebgpu_render_pass_encoder_end(
 		p.ref,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	return
 }

--- a/wgpu/surface.go
+++ b/wgpu/surface.go
@@ -114,7 +114,7 @@ func (p *Surface) GetCurrentTexture() (*Texture, error) {
 	ref := C.gowebgpu_surface_get_current_texture(
 		p.ref,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		if ref != nil {

--- a/wgpu/texture.go
+++ b/wgpu/texture.go
@@ -68,7 +68,7 @@ func (p *Texture) CreateView(descriptor *TextureViewDescriptor) (*TextureView, e
 		p.ref,
 		desc,
 		p.deviceRef,
-		unsafe.Pointer(&errorCallbackHandle),
+		unsafe.Pointer(errorCallbackHandle),
 	)
 	if err != nil {
 		C.wgpuTextureViewRelease(ref)


### PR DESCRIPTION
# Summary: Fixed Memory Corruption Panic in Async Callbacks

## The Bug
The library was misusing `cgo.Handle` in every asynchronous function (e.g., `MapAsync`, `RequestAdapter`, `RequestDevice`, and internal error scope checks).

The code was creating a `cgo.Handle` and then passing a **pointer to that local variable** (`unsafe.Pointer(&handle)`) to a C function. Since these functions are asynchronous, the Go function returns immediately and its stack frame is destroyed. When the C callback eventually fires, it attempts to dereference that now-invalid stack pointer to retrieve the handle, leading to:
`panic: runtime/cgo: misuse of an invalid Handle`

## Affected Platforms
This issue likely affects all desktop platforms (macOS, Windows, Linux) where Go's CGO implementation is used. It was specifically observed and reproduced on **macOS**.

## How to Reproduce
1. Use any asynchronous function in the library, such as `Buffer.MapAsync`.
2. Perform frequent asynchronous operations (e.g., reading back data every frame).
3. Within 10-20 seconds, the application will crash with a `runtime/cgo` panic when a callback attempts to process an invalid pointer from a previous call's stack.

## The Fix
The fix implements the standard, safe pattern for passing `cgo.Handle` through C:

1. **Pass by Value**: Instead of passing the address of the handle variable, the handle (which is a `uintptr` under the hood) is converted directly to an `unsafe.Pointer` and passed as the `userdata`.
   ```go
   // Before (BROKEN)
   handle := cgo.NewHandle(cb)
   C.some_async_func(..., unsafe.Pointer(&handle))

   // After (FIXED)
   handle := cgo.NewHandle(cb)
   C.some_async_func(..., unsafe.Pointer(handle))
   ```

2. **Cast on Recovery**: In the Go callback exported to C, the `userdata` is cast back to a `cgo.Handle` directly without dereferencing a pointer.
   ```go
   // Before (BROKEN)
   handle := *(*cgo.Handle)(userdata)

   // After (FIXED)
   handle := cgo.Handle(userdata)
   ```

This ensures that the handle value itself is preserved in the C `userdata` field, independent of the lifetime of the calling function's stack.
