### PR TITLE
Add missing reference to linux/arm64.

### DIFF
--- a/wgpu/lib/vendor.go
+++ b/wgpu/lib/vendor.go
@@ -13,5 +13,6 @@ import (
 	_ "github.com/cogentcore/webgpu/wgpu/lib/ios/amd64"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/ios/arm64"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/linux/amd64"
+	_ "github.com/cogentcore/webgpu/wgpu/lib/linux/arm64"
 	_ "github.com/cogentcore/webgpu/wgpu/lib/windows/amd64"
 )


### PR DESCRIPTION
- This enables compilation under the Raspberry Pi 5.
- One still needs CGO_ENABLED=1 to compile (it defaults to 0 on linux/arm64 apparently. At least when installed using homebrew).
