### PR TITLE
device: Fix `wgpuDeviceRelease()` being called when releasing other objects

### DIFF
--- a/wgpu/buffer.go
+++ b/wgpu/buffer.go
@@ -23,7 +23,6 @@ static inline void gowebgpu_buffer_unmap(WGPUBuffer buffer, WGPUDevice device, v
 }
 
 static inline void gowebgpu_buffer_release(WGPUBuffer buffer, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuBufferRelease(buffer);
 }
 

--- a/wgpu/command_encoder.go
+++ b/wgpu/command_encoder.go
@@ -78,7 +78,6 @@ static inline void gowebgpu_command_encoder_write_timestamp(WGPUCommandEncoder c
 }
 
 static inline void gowebgpu_command_encoder_release(WGPUCommandEncoder commandEncoder, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuCommandEncoderRelease(commandEncoder);
 }
 

--- a/wgpu/compute_pass_encoder.go
+++ b/wgpu/compute_pass_encoder.go
@@ -16,7 +16,6 @@ static inline void gowebgpu_compute_pass_encoder_end(WGPUComputePassEncoder comp
 }
 
 static inline void gowebgpu_compute_pass_encoder_release(WGPUComputePassEncoder computePassEncoder, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuComputePassEncoderRelease(computePassEncoder);
 }
 

--- a/wgpu/queue.go
+++ b/wgpu/queue.go
@@ -23,7 +23,6 @@ static inline void gowebgpu_queue_write_texture(WGPUQueue queue, WGPUImageCopyTe
 }
 
 static inline void gowebgpu_queue_release(WGPUQueue queue, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuQueueRelease(queue);
 }
 

--- a/wgpu/render_pass_encoder.go
+++ b/wgpu/render_pass_encoder.go
@@ -16,7 +16,6 @@ static inline void gowebgpu_render_pass_encoder_end(WGPURenderPassEncoder render
 }
 
 static inline void gowebgpu_render_pass_encoder_release(WGPURenderPassEncoder renderPassEncoder, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuRenderPassEncoderRelease(renderPassEncoder);
 }
 

--- a/wgpu/texture.go
+++ b/wgpu/texture.go
@@ -18,7 +18,6 @@ static inline WGPUTextureView gowebgpu_texture_create_view(WGPUTexture texture, 
 }
 
 static inline void gowebgpu_texture_release(WGPUTexture texture, WGPUDevice device) {
-	wgpuDeviceRelease(device);
 	wgpuTextureRelease(texture);
 }
 


### PR DESCRIPTION
A little confused about why this was being done in the first place - the fact that it's being done in multiple object release functions leads me to believe this was somehow intentional, but I really can't figure out why.

Either way, putting this PR up because it fixes texture freeing invalidating the device for a project of mine.